### PR TITLE
Display scrollbar across whole page height

### DIFF
--- a/notes.css
+++ b/notes.css
@@ -41,11 +41,6 @@ body {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  top: 5px;
-  left: 5px;
-  position: relative;
-  border-width: 5px;
-  border-style: solid;
 }
 
 #minus, #plus {
@@ -74,7 +69,6 @@ body {
 }
 
 #light #mode {
-  border-color: white;
   background: black;
 }
 
@@ -92,6 +86,5 @@ body {
 }
 
 #dark #mode {
-  border-color: #36393f;
   background: white;
 }

--- a/notes.css
+++ b/notes.css
@@ -29,9 +29,8 @@ body {
   font-size: 300%;
   font-family: monospace;
   bottom: 0;
-  right: 0;
+  right: 5px;
   padding: 20px;
-  background: white;
   cursor: pointer;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
@@ -65,8 +64,7 @@ body {
 /* Light mode */
 
 #light,
-#light #textarea,
-#light #settings {
+#light #textarea {
   background: white;
   color: black;
 }
@@ -84,8 +82,7 @@ body {
 /* Dark mode */
 
 #dark,
-#dark #textarea,
-#dark #settings {
+#dark #textarea {
   background: #36393f;
   color: white;
 }


### PR DESCRIPTION
This is a solution for https://github.com/penge/my-notes/issues/16

**Before:** scrollbar was hidden under the `#settings` when getting to the bottom, it would squash the scrollbar.

**Now:** scrollbar is OVER the `#settings`, the scrollbar has full-page height now and it does not squash anymore.

This behavior was reported by: @MichaelWehar 
Thank you for the report!