### PR TITLE
Add Font selection

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,27 @@
+"use strict";
+
+/* global chrome */
+
+/*
+Font selection is in "options.html"
+
+<div class="selection">
+  <input type="radio" id="courier-new" name="font" value="Courier New" data-generic="monospace">
+  <label for="courier-new" style="font-family:Courier New,monospace;">The quick brown fox jumps over the lazy dog (Courier New)</label>
+</div>
+*/
+var defaultFont = {
+  id: "courier-new",
+  name: "Courier New",
+  genericFamily: "monospace",
+  fontFamily: "Courier New,monospace" // fallback is always the generic
+};
+
+chrome.runtime.onInstalled.addListener(function () {
+  chrome.storage.sync.set({
+    // Font is set upon installation of the plugin.
+    // The reason: You may visit My Notes, or My Notes Options page
+    // in unspecified order. At that point, the font must be set.
+    font: defaultFont
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,12 @@
   "name": "My Notes",
   "description": "Chrome Extension that turns your \"New Tab\" into a note taking tool.",
   "version": "1.3",
+  "options_page": "options.html",
   "permissions": ["storage"],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
   "chrome_url_overrides" : {
     "newtab": "newtab.html"
   }

--- a/notes.js
+++ b/notes.js
@@ -37,19 +37,19 @@ const setMode = (mode) => {
 
 /* Font size */
 
-const minSize = 150;
+const minSize = 100;
 const maxSize = 600;
 const defaultSize = 200;
 
 minus.addEventListener("click", function () {
-  const size = currentSize() - 50;
+  const size = currentSize() - 25;
   if (size >= minSize) {
     changeSize(size);
   }
 });
 
 plus.addEventListener("click", function () {
-  const size = currentSize() + 50;
+  const size = currentSize() + 25;
   if (size <= maxSize) {
     changeSize(size);
   }
@@ -69,9 +69,10 @@ mode.addEventListener("click", function () {
 
 /* Storage */
 
-chrome.storage.sync.get(["value", "size", "mode"], result => {
+chrome.storage.sync.get(["value", "size", "font", "mode"], result => {
   textarea.value = result.value || "";
   textarea.style.fontSize = (result.size || defaultSize) + "%";
+  textarea.style.fontFamily = result.font.fontFamily;
   setPlaceholder();
   setMode(result.mode || defaultMode);
 });

--- a/options.css
+++ b/options.css
@@ -1,0 +1,48 @@
+body {
+  padding: 50px;
+  font-family: Calibri, Arial;
+  font-size: 150%;
+}
+
+h3 {
+  padding-top: 50px;
+}
+
+#current-font-name {
+  padding: 0px 8px;
+  font-weight: bold;
+}
+
+.font-generic {
+  cursor: pointer;
+}
+
+.divider {
+  padding: 0 12px;
+}
+
+.fonts {
+  display: none;
+}
+
+.selection {
+  padding: 10px 0px;
+  font-size: 80%;
+}
+
+#comment {
+  font-size: 70%;
+  padding-top: 80px;
+  line-height: 150%;
+  opacity: .5;
+}
+
+@media only screen and (max-width: 600px) {
+  .font-generic {
+    display: block;
+  }
+
+  .divider {
+    display: none;
+  }
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Notes</title>
+  <link rel="stylesheet" href="options.css">
+</head>
+
+<body>
+  <h1>My Notes</h1>
+  <h2>Font</h2>
+  <p>Current font: <span id="current-font-name"></span></p>
+
+  <h3>
+    <span id="serif" class="font-generic">Serif</span><span class="divider">/</span
+    ><span id="sans-serif" class="font-generic">Sans-serif</span><span class="divider">/</span
+    ><span id="monospace" class="font-generic">Monospace</span>
+  </h3>
+
+
+  <div id="serif-fonts" class="fonts">
+    <div class="selection">
+      <input type="radio" id="times" name="font" value="Times" data-generic="serif">
+      <label for="times" style="font-family:Times,serif;">The quick brown fox jumps over the lazy dog (Times)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="times-new-roman" name="font" value="Times New Roman" data-generic="serif">
+      <label for="times-new-roman" style="font-family:Times New Roman,serif;">The quick brown fox jumps over the lazy dog (Times New Roman)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="georgia" name="font" value="Georgia" data-generic="serif">
+      <label for="georgia" style="font-family:Georgia,serif;">The quick brown fox jumps over the lazy dog (Georgia)</label>
+    </div>
+  </div>
+
+
+  <div id="sans-serif-fonts" class="fonts">
+    <div class="selection">
+      <input type="radio" id="arial" name="font" value="Arial" data-generic="sans-serif">
+      <label for="arial" style="font-family:Arial,sans-serif;">The quick brown fox jumps over the lazy dog (Arial)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="arial-black" name="font" value="Arial Black" data-generic="sans-serif">
+      <label for="arial-black" style="font-family:Arial Black,sans-serif;">The quick brown fox jumps over the lazy dog (Arial Black)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="verdana" name="font" value="Verdana" data-generic="sans-serif">
+      <label for="verdana" style="font-family:Verdana,sans-serif;">The quick brown fox jumps over the lazy dog (Verdana)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="tahoma" name="font" value="Tahoma" data-generic="sans-serif">
+      <label for="tahoma" style="font-family:Tahoma,sans-serif;">The quick brown fox jumps over the lazy dog (Tahoma)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="comic-sans-ms" name="font" value="Comic Sans MS" data-generic="sans-serif">
+      <label for="comic-sans-ms" style="font-family:Comic Sans MS,sans-serif;">The quick brown fox jumps over the lazy dog (Comic Sans)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="impact" name="font" value="Impact" data-generic="sans-serif">
+      <label for="impact" style="font-family:Impact,sans-serif;">The quick brown fox jumps over the lazy dog (Impact)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="roboto" name="font" value="Roboto" data-generic="sans-serif">
+      <label for="roboto" style="font-family:Roboto,sans-serif;">The quick brown fox jumps over the lazy dog (Roboto)</label>
+    </div>
+  </div>
+
+
+  <div id="monospace-fonts" class="fonts">
+    <div class="selection">
+      <input type="radio" id="courier" name="font" value="Courier" data-generic="monospace">
+      <label for="courier" style="font-family:Courier,monospace;">The quick brown fox jumps over the lazy dog (Courier)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="courier-new" name="font" value="Courier New" data-generic="monospace">
+      <label for="courier-new" style="font-family:Courier New,monospace;">The quick brown fox jumps over the lazy dog (Courier New)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="lucida-console" name="font" value="Lucida Console" data-generic="monospace">
+      <label for="lucida-console" style="font-family:Lucida Console,monospace;">The quick brown fox jumps over the lazy dog (Lucida Console)</label>
+    </div>
+
+    <div class="selection">
+      <input type="radio" id="monaco" name="font" value="Monaco" data-generic="monospace">
+      <label for="monaco" style="font-family:Monaco,monospace;">The quick brown fox jumps over the lazy dog (Monaco)</label>
+    </div>
+  </div>
+
+
+  <p id="comment">
+    You may select your new font from the selection above.<br>
+    The look of the font may depend on the compatibility of your browser.<br><br>
+    If you have any ideas or requests, do not hesitate to contact me at:<br>
+    <strong>bucka.pavel@gmail.com</strong>
+  </p>
+
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,88 @@
+"use strict";
+
+(function () {
+
+/* global chrome */
+
+/* Elements */
+
+var generics = [
+  document.getElementById("serif"),
+  document.getElementById("sans-serif"),
+  document.getElementById("monospace")
+];
+
+var fonts = [
+  document.getElementById("serif-fonts"),
+  document.getElementById("sans-serif-fonts"),
+  document.getElementById("monospace-fonts")
+];
+
+var checkboxes = document.getElementsByName("font");
+var currentFontName = document.getElementById("current-font-name");
+
+
+/* Helpers */
+
+function setCurrentFontNameText(fontName) {
+  currentFontName.innerText = fontName;
+}
+
+function checkCurrentFontCheckbox(fontId) {
+  document.getElementById(fontId).checked = true;
+}
+
+function displayGeneric(id) {
+  generics.forEach(generic => {
+    var decoration = generic.id === id ? "underline" : "";
+    generic.style.textDecoration = decoration;
+  });
+
+  fonts.forEach(font => {
+    var display = (font.id === id + '-fonts') ? "block" : "none";
+    font.style.display = display;
+  });
+}
+
+
+/* Events */
+
+generics.forEach(generic => {
+  generic.addEventListener("click", function () {
+    displayGeneric(this.id);
+  });
+});
+
+
+checkboxes.forEach(checkbox => {
+  checkbox.addEventListener("click", function () {
+    var font = {
+      id: this.id,
+      name: this.value,
+      genericFamily: this.dataset.generic,
+      fontFamily: [this.value, this.dataset.generic].join(',')
+    };
+
+    chrome.storage.sync.set({ font: font });
+    setCurrentFontNameText(font.name);
+  });
+});
+
+
+/* Storage */
+
+chrome.storage.sync.get(["font"], result => {
+  var currentFont = result.font; // see background.js
+  var currentGeneric = currentFont.genericFamily;
+
+  // Display the name of the current font
+  setCurrentFontNameText(currentFont.name);
+
+  // Check the current font
+  checkCurrentFontCheckbox(currentFont.id);
+
+  // Underline the generic and display its fonts
+  displayGeneric(currentGeneric);
+});
+
+})(); // IIFE


### PR DESCRIPTION
This is a solution to https://github.com/penge/my-notes/issues/17 reported by @nickforddesign

**Goal: Add Font selection.**

**Details:**
- Add **Options** page (that contains **Font selection**)
- Add `background.js` (to set the default font)
- Resize the font in smoother 25% steps (before 50%)