### PR TITLE
Optimize text save with debounce and beforeunload

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "Chrome Extension that turns your \"New Tab\" into a note taking tool.",
-  "version": "1.3",
+  "version": "1.4",
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
   "permissions": ["storage"],


### PR DESCRIPTION
Solution to https://github.com/penge/my-notes/issues/25

Using **debounce** to save text in 1 second intervals, to be below `MAX_WRITE_OPERATIONS_PER_MINUTE` quota.

Using **beforeunload** to save text in case window was closed before the next **debounce.**

## Milestone

This is a milestone. Releasing **1.4!**