### PR TITLE
Move mode selection (light/dark) to Options page

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,26 +2,21 @@
 
 /* global chrome */
 
-/*
-Font selection is in "options.html"
-
-<div class="selection">
-  <input type="radio" id="courier-new" name="font" value="Courier New" data-generic="monospace">
-  <label for="courier-new" style="font-family:Courier New,monospace;">The quick brown fox jumps over the lazy dog (Courier New)</label>
-</div>
-*/
-var defaultFont = {
+const defaultFont = {
   id: "courier-new",
   name: "Courier New",
   genericFamily: "monospace",
   fontFamily: "Courier New,monospace" // fallback is always the generic
 };
 
+const defaultMode = "light"; // "light", "dark"
+
 chrome.runtime.onInstalled.addListener(function () {
   chrome.storage.sync.set({
     // Font is set upon installation of the plugin.
     // The reason: You may visit My Notes, or My Notes Options page
     // in unspecified order. At that point, the font must be set.
-    font: defaultFont
+    font: defaultFont,
+    mode: defaultMode
   });
 });

--- a/debounce.js
+++ b/debounce.js
@@ -1,0 +1,19 @@
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+function debounce(func, wait, immediate) {
+  var timeout;
+  return function () {
+    var context = this,
+      args = arguments;
+    var later = function () {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    var callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "options_page": "options.html",
   "permissions": ["storage"],
   "background": {
-    "scripts": ["background.js"],
+    "scripts": ["debounce.js", "background.js"],
     "persistent": false
   },
   "chrome_url_overrides": {

--- a/notes.css
+++ b/notes.css
@@ -28,6 +28,7 @@ body {
   position: fixed;
   font-size: 300%;
   font-family: monospace;
+  font-weight: bold;
   bottom: 0;
   right: 5px;
   padding: 20px;
@@ -36,23 +37,12 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-#mode {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-}
-
 #minus, #plus {
   display: inline-block;
 }
 
 #minus {
   font-size: 75%;
-}
-
-#plus {
-  font-weight: bold;
 }
 
 
@@ -68,10 +58,6 @@ body {
   color: silver;
 }
 
-#light #mode {
-  background: black;
-}
-
 
 /* Dark mode */
 
@@ -83,8 +69,4 @@ body {
 
 #dark #textarea::placeholder {
   color: #e0e0e0;
-}
-
-#dark #mode {
-  background: white;
 }

--- a/notes.html
+++ b/notes.html
@@ -11,7 +11,6 @@
 <body>
   <textarea id="textarea" style="font-size:200%"></textarea>
   <div id="settings">
-    <div id="mode"></div>
     <div id="minus">A</div>
     <div id="plus">A</div>
   </div>

--- a/notes.js
+++ b/notes.js
@@ -7,7 +7,6 @@
 /* Elements */
 
 const textarea = document.getElementById("textarea");
-const mode = document.getElementById("mode");
 const minus = document.getElementById("minus");
 const plus = document.getElementById("plus");
 
@@ -27,11 +26,6 @@ const currentSize = () => {
 const changeSize = (size) => {
   textarea.style.fontSize = size + "%";
   chrome.storage.sync.set({ size: size });
-};
-
-const setMode = (mode) => {
-  document.body.id = mode;
-  chrome.storage.sync.set({ mode: mode });
 };
 
 
@@ -56,17 +50,6 @@ plus.addEventListener("click", function () {
 });
 
 
-/* Mode */
-
-const defaultMode = "light";
-let currentMode = "light";
-
-mode.addEventListener("click", function () {
-  currentMode = currentMode === "light" ? "dark" : "light";
-  setMode(currentMode);
-});
-
-
 /* Storage */
 
 let mostRecentValue;
@@ -81,7 +64,7 @@ chrome.storage.sync.get(["value", "size", "font", "mode"], result => {
   textarea.style.fontFamily = result.font.fontFamily;
 
   setPlaceholder();
-  setMode(result.mode || defaultMode);
+  document.body.id = result.mode;
 });
 
 
@@ -97,26 +80,6 @@ function isShift(event) {
   return event.shiftKey;
 }
 
-// Returns a function, that, as long as it continues to be invoked, will not
-// be triggered. The function will be called after it stops being called for
-// N milliseconds. If `immediate` is passed, trigger the function on the
-// leading edge, instead of the trailing.
-function debounce(func, wait, immediate) {
-  var timeout;
-  return function () {
-    var context = this,
-      args = arguments;
-    var later = function () {
-      timeout = null;
-      if (!immediate) func.apply(context, args);
-    };
-    var callNow = immediate && !timeout;
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-    if (callNow) func.apply(context, args);
-  };
-}
-
 function saveText() {
   if (mostRecentValue === mostRecentSavedValue) {
     return;
@@ -128,7 +91,7 @@ function saveText() {
   });
 }
 
-const saveTextDebounce = debounce(saveText, 1000, true);
+const saveTextDebounce = chrome.extension.getBackgroundPage().debounce(saveText, 1000, true);
 
 textarea.addEventListener("keydown", (event) => {
   if (isTab(event)) {

--- a/options.css
+++ b/options.css
@@ -30,11 +30,25 @@ h3 {
   font-size: 80%;
 }
 
-#comment {
+.comment {
   font-size: 70%;
-  padding-top: 80px;
+  padding-top: 30px;
   line-height: 150%;
   opacity: .5;
+}
+
+#mode {
+  padding-top: 40px;
+}
+
+#light {
+  background: white;
+  color: black;
+}
+
+#dark {
+  background: #36393f;
+  color: white;
 }
 
 @media only screen and (max-width: 600px) {

--- a/options.html
+++ b/options.html
@@ -98,10 +98,33 @@
     </div>
   </div>
 
-
-  <p id="comment">
+  <p class="comment">
     You may select your new font from the selection above.<br>
-    The look of the font may depend on the compatibility of your browser.<br><br>
+    The look of the font may depend on the compatibility of your browser.
+  </p>
+
+
+  <h2 id="mode">Mode</h2>
+  <div>
+    <div class="selection">
+      <input type="radio" id="light" name="mode" value="light">
+      <label for="light">Light mode</label>
+    </div>
+    <div class="selection">
+      <input type="radio" id="dark" name="mode" value="dark">
+      <label for="dark">Dark mode</label>
+    </div>
+  </div>
+
+  <p class="comment">
+    Light mode has white background with dark text.<br>
+    Dark mode has dark background with white text.<br>
+    To see the changes, you may need to refresh My Notes page.
+  </p>
+
+
+  <p class="comment">
+    <br><br><br><br>
     If you have any ideas or requests, do not hesitate to contact me at:<br>
     <strong>bucka.pavel@gmail.com</strong>
   </p>

--- a/options.js
+++ b/options.js
@@ -4,7 +4,7 @@
 
 /* global chrome */
 
-/* Elements */
+/* Font elements */
 
 var generics = [
   document.getElementById("serif"),
@@ -18,8 +18,13 @@ var fonts = [
   document.getElementById("monospace-fonts")
 ];
 
-var checkboxes = document.getElementsByName("font");
+var fontCheckboxes = document.getElementsByName("font");
 var currentFontName = document.getElementById("current-font-name");
+
+
+/* Mode elements */
+
+var modeCheckboxes = document.getElementsByName("mode");
 
 
 /* Helpers */
@@ -28,8 +33,8 @@ function setCurrentFontNameText(fontName) {
   currentFontName.innerText = fontName;
 }
 
-function checkCurrentFontCheckbox(fontId) {
-  document.getElementById(fontId).checked = true;
+function checkCheckboxById(id) {
+  document.getElementById(id).checked = true;
 }
 
 function displayGeneric(id) {
@@ -53,10 +58,9 @@ generics.forEach(generic => {
   });
 });
 
-
-checkboxes.forEach(checkbox => {
+fontCheckboxes.forEach(checkbox => {
   checkbox.addEventListener("click", function () {
-    var font = {
+    const font = {
       id: this.id,
       name: this.value,
       genericFamily: this.dataset.generic,
@@ -68,10 +72,19 @@ checkboxes.forEach(checkbox => {
   });
 });
 
+modeCheckboxes.forEach(checkbox => {
+  checkbox.addEventListener("click", function () {
+    const mode = this.id;
+    document.body.id = mode;
+    chrome.storage.sync.set({ mode: mode });
+  });
+});
+
 
 /* Storage */
 
-chrome.storage.sync.get(["font"], result => {
+chrome.storage.sync.get(["font", "mode"], result => {
+  // 1 FONT
   var currentFont = result.font; // see background.js
   var currentGeneric = currentFont.genericFamily;
 
@@ -79,10 +92,15 @@ chrome.storage.sync.get(["font"], result => {
   setCurrentFontNameText(currentFont.name);
 
   // Check the current font
-  checkCurrentFontCheckbox(currentFont.id);
+  checkCheckboxById(currentFont.id);
 
   // Underline the generic and display its fonts
   displayGeneric(currentGeneric);
+
+
+  // 2 MODE
+  checkCheckboxById(result.mode);
+  document.body.id = result.mode;
 });
 
 })(); // IIFE


### PR DESCRIPTION
This is a solution to https://github.com/penge/my-notes/issues/29

### Changes

- Move mode selection (light/dark mode) to the **Options page** (UI is now more simple)
- Apply light/dark mode to the **Options page** as well (consistent style)
- Move debounce function to `debounce.js` (separation of concerns)
- Remove `setMode` function (no longer required)
- Set **bold** font to both **small A** and **large A** (look more nice)

### Screenshots

![light](https://user-images.githubusercontent.com/907255/70592184-7caaae80-1c0b-11ea-81d8-1bae95628b97.png)

![dark](https://user-images.githubusercontent.com/907255/70592188-7e747200-1c0b-11ea-95ff-8499074211b7.png)
