### PR TITLE
Add pages (1,2,3) and focus mode

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,6 +12,9 @@ const defaultFont = {
 const defaultMode = "light"; // "light", "dark"
 const defaultSize = 200;
 
+const defaultNotes = ["", "", ""];
+const defaultIndex = 0;
+
 chrome.runtime.onInstalled.addListener(function () {
   chrome.storage.sync.set({
     // Font is set upon installation of the plugin.
@@ -19,6 +22,8 @@ chrome.runtime.onInstalled.addListener(function () {
     // in unspecified order. At that point, the font must be set.
     font: defaultFont,
     mode: defaultMode,
-    size: defaultSize
+    size: defaultSize,
+    notes: defaultNotes,
+    index: defaultIndex
   });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,13 @@
         "mac": "Alt+3"
       },
       "description": "Set page 3"
+    },
+    "focus": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F",
+        "mac": "Alt+F"
+      },
+      "description": "Toggle focus mode"
     }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -12,5 +12,28 @@
   },
   "chrome_url_overrides": {
     "newtab": "notes.html"
+  },
+  "commands": {
+    "page-1": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+1",
+        "mac": "Alt+1"
+      },
+      "description": "Set page 1"
+    },
+    "page-2": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+2",
+        "mac": "Alt+2"
+      },
+      "description": "Set page 2"
+    },
+    "page-3": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+3",
+        "mac": "Alt+3"
+      },
+      "description": "Set page 3"
+    }
   }
 }

--- a/notes.css
+++ b/notes.css
@@ -49,6 +49,10 @@ body {
   font-size: 75%;
 }
 
+.hide {
+  display: none;
+}
+
 
 /* Light mode */
 

--- a/notes.css
+++ b/notes.css
@@ -37,8 +37,12 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-#minus, #plus {
+#page, #minus, #plus {
   display: inline-block;
+}
+
+#page {
+  font-size: 50%;
 }
 
 #minus {

--- a/notes.html
+++ b/notes.html
@@ -11,6 +11,7 @@
 <body>
   <textarea id="textarea" style="font-size:200%"></textarea>
   <div id="settings">
+    <div id="page"></div>
     <div id="minus">A</div>
     <div id="plus">A</div>
   </div>

--- a/notes.js
+++ b/notes.js
@@ -7,6 +7,7 @@
 /* Elements */
 
 const textarea = document.getElementById("textarea");
+const page = document.getElementById("page");
 const minus = document.getElementById("minus");
 const plus = document.getElementById("plus");
 
@@ -39,9 +40,13 @@ const setSize = (size) => {
   currentSize = size;
 };
 
-const saveSize = () => {
+const saveSize = (onlyKeys) => {
   if (currentSize === savedSize) {
     return;
+  }
+
+  if (onlyKeys) {
+    return { size: currentSize };
   }
 
   chrome.storage.sync.set({ size: currentSize });
@@ -62,21 +67,67 @@ plus.addEventListener("click", function () {
 });
 
 
+/* Page */
+
+let savedNotes;
+let savedIndex;
+
+let currentNotes;
+let currentIndex;
+
+const setPage = (notes, index) => {
+  page.innerText = (index + 1) + "/" + notes.length;
+  textarea.value = notes[index];
+}
+
+const saveIndex = (onlyKeys) => {
+  if (currentIndex === savedIndex) {
+    return;
+  }
+
+  if (onlyKeys) {
+    return { index: currentIndex };
+  }
+
+  chrome.storage.sync.set({ index: currentIndex });
+};
+
+page.addEventListener("click", function () {
+  currentIndex += 1;
+  if (currentIndex === currentNotes.length) {
+    currentIndex = 0;
+  }
+  setPage(currentNotes, currentIndex);
+});
+
+chrome.commands.onCommand.addListener(function(command) {
+  if (command.startsWith("page-")) {
+    const pageNumber = command.split("page-")[1];
+    const newIndex = parseInt(pageNumber) - 1;
+    if (currentIndex === newIndex) {
+      return;
+    }
+    currentIndex = newIndex;
+    setPage(currentNotes, currentIndex);
+    return;
+  }
+});
+
+
 /* Storage */
 
-let mostRecentValue;
-let mostRecentSavedValue;
-
-chrome.storage.sync.get(["value", "size", "font", "mode"], result => {
-  textarea.value = result.value || "";
-  mostRecentValue = textarea.value;
-  mostRecentSavedValue = textarea.value;
-
+chrome.storage.sync.get(["notes", "index", "size", "font", "mode"], result => {
+  savedNotes = result.notes.slice();
+  savedIndex = result.index;
   savedSize = result.size;
+
+  currentNotes = result.notes.slice();
+  currentIndex = result.index;
 
   setFont(result.font.fontFamily);
   setSize(result.size);
   setPlaceholder();
+  setPage(currentNotes, currentIndex);
 
   document.body.id = result.mode;
 });
@@ -94,18 +145,29 @@ function isShift(event) {
   return event.shiftKey;
 }
 
-function saveText() {
-  if (mostRecentValue === mostRecentSavedValue) {
+function saveNotes(onlyKeys) {
+  let changed = false;
+  for (let i = 0; i < savedNotes.length; i++) {
+    if (savedNotes[i] !== currentNotes[i]) {
+      changed = true;
+      break;
+    }
+  }
+
+  if (!changed) {
     return;
   }
 
-  const value = textarea.value;
-  chrome.storage.sync.set({ value: value }, function () {
-    mostRecentSavedValue = value;
+  if (onlyKeys) {
+    return { notes: currentNotes };
+  }
+
+  chrome.storage.sync.set({ notes: currentNotes }, function () {
+    savedNotes = currentNotes.slice();
   });
 }
 
-const saveTextDebounce = chrome.extension.getBackgroundPage().debounce(saveText, 1000, true);
+const saveNotesDebounce = chrome.extension.getBackgroundPage().debounce(saveNotes, 1000, true);
 
 textarea.addEventListener("keydown", (event) => {
   if (isTab(event)) {
@@ -151,18 +213,24 @@ textarea.addEventListener("keyup", (event) => {
   }
 
   // Do not save text if unchanged (Ctrl, Alt, Shift, Arrow keys)
-  if (mostRecentValue === textarea.value) {
+  if (currentNotes[currentIndex] === textarea.value) {
     return;
   }
 
-  mostRecentValue = textarea.value;
+  currentNotes[currentIndex] = textarea.value;
   setPlaceholder();
-  saveTextDebounce();
+  saveNotesDebounce();
 });
 
 window.addEventListener("beforeunload", function () {
-  saveText();
-  saveSize();
+  const notes = saveNotes(true);
+  const size = saveSize(true);
+  const index = saveIndex(true);
+
+  const keyValues = Object.assign({}, notes, size, index);
+  if (Object.keys(keyValues).length > 0) {
+    chrome.storage.sync.set(keyValues);
+  }
 });
 
 })(); // IIFE

--- a/notes.js
+++ b/notes.js
@@ -7,6 +7,7 @@
 /* Elements */
 
 const textarea = document.getElementById("textarea");
+const settings = document.getElementById("settings");
 const page = document.getElementById("page");
 const minus = document.getElementById("minus");
 const plus = document.getElementById("plus");
@@ -109,6 +110,11 @@ chrome.commands.onCommand.addListener(function(command) {
     }
     currentIndex = newIndex;
     setPage(currentNotes, currentIndex);
+    return;
+  }
+
+  if (command === "focus") {
+    settings.classList.toggle("hide");
     return;
   }
 });

--- a/notes.js
+++ b/notes.js
@@ -173,7 +173,17 @@ function saveNotes(onlyKeys) {
   });
 }
 
-const saveNotesDebounce = chrome.extension.getBackgroundPage().debounce(saveNotes, 1000, true);
+let _saveNotesDebounce;
+const saveNotesDebounce = function () {
+  if (!_saveNotesDebounce) {
+    chrome.runtime.getBackgroundPage(function (backgroundPage) {
+      _saveNotesDebounce = backgroundPage.debounce(saveNotes, 1000);
+      _saveNotesDebounce();
+    });
+  } else {
+    _saveNotesDebounce();
+  }
+}
 
 textarea.addEventListener("keydown", (event) => {
   if (isTab(event)) {
@@ -223,9 +233,9 @@ textarea.addEventListener("keyup", (event) => {
     return;
   }
 
-  currentNotes[currentIndex] = textarea.value;
+  currentNotes[currentIndex] = textarea.value; // save notes locally
   setPlaceholder();
-  saveNotesDebounce();
+  saveNotesDebounce(); // save notes to the storage
 });
 
 window.addEventListener("beforeunload", function () {


### PR DESCRIPTION
Solution to https://github.com/penge/my-notes/issues/27 and https://github.com/penge/my-notes/issues/28

## Changes

- Add **pages** (1,2,3)
- Add **focus mode**
- Use **trailing** edge to save the notes (before leading)
- Use `chrome.runtime.getBackgroundPage`

## Pages

To change the page, you have 2 options:
<ol type="A">
  <li>Click the page number in the bottom</li>
  <li>Use keyboard shortcuts</li>
</ol>

On Windows, Linux, and Chrome OS:
- `Ctrl+Shift+1`
- `Ctrl+Shift+2`
- `Ctrl+Shift+3`

On Mac:
- `Option+1`
- `Option+2`
- `Option+3`

## Focus mode

There is also focus mode added. To hide (toggle) the controls via a keyboard shortcut and to focus on the content.

On Windows, Linux, and Chrome OS:
- `Ctrl+Shift+F`

On Mac:
- `Option+F`

## Screenshots

![page-1](https://user-images.githubusercontent.com/907255/70621296-d7fc9100-1c4b-11ea-9a74-abfe379e6da3.png)

![page-2](https://user-images.githubusercontent.com/907255/70621298-d8952780-1c4b-11ea-9e3f-96ae03a20f45.png)

![page-3](https://user-images.githubusercontent.com/907255/70621299-d8952780-1c4b-11ea-84ae-dbae42aa0450.png)
