### PR TITLE
Use local storage, Add slider, Fix placeholder

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,6 +2,9 @@
 
 /* global chrome */
 
+const defaultNotes = ["", "", ""];
+const defaultIndex = 0;
+
 const defaultFont = {
   id: "courier-new",
   name: "Courier New",
@@ -9,21 +12,18 @@ const defaultFont = {
   fontFamily: "Courier New,monospace" // fallback is always the generic
 };
 
-const defaultMode = "light"; // "light", "dark"
 const defaultSize = 200;
-
-const defaultNotes = ["", "", ""];
-const defaultIndex = 0;
+const defaultMode = "light"; // "light", "dark"
 
 chrome.runtime.onInstalled.addListener(function () {
   chrome.storage.sync.set({
-    // Font is set upon installation of the plugin.
-    // The reason: You may visit My Notes, or My Notes Options page
-    // in unspecified order. At that point, the font must be set.
+    notes: defaultNotes
+  });
+
+  chrome.storage.local.set({
+    index: defaultIndex,
     font: defaultFont,
-    mode: defaultMode,
     size: defaultSize,
-    notes: defaultNotes,
-    index: defaultIndex
+    mode: defaultMode
   });
 });

--- a/notes.css
+++ b/notes.css
@@ -37,16 +37,9 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-#page, #minus, #plus {
-  display: inline-block;
-}
-
 #page {
-  font-size: 50%;
-}
-
-#minus {
-  font-size: 75%;
+  font-size: 65%;
+  text-align: right;
 }
 
 .hide {
@@ -77,4 +70,39 @@ body {
 
 #dark #textarea::placeholder {
   color: #e0e0e0;
+}
+
+
+/* Slider */
+
+.slidecontainer {
+  width: 100%;
+}
+
+.slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 3px;
+  border-radius: 3px;
+  background: #d3d3d3;
+  outline: none;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: black;
+  cursor: pointer;
+}
+
+.slider::-moz-range-thumb {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: black;
+  cursor: pointer;
 }

--- a/notes.html
+++ b/notes.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-  <textarea id="textarea" style="font-size:200%"></textarea>
+  <textarea id="textarea" style="font-size:200%" placeholder="Type your notes here."></textarea>
   <div id="settings">
     <div id="page"></div>
     <div class="slidecontainer">

--- a/notes.html
+++ b/notes.html
@@ -12,8 +12,9 @@
   <textarea id="textarea" style="font-size:200%"></textarea>
   <div id="settings">
     <div id="page"></div>
-    <div id="minus">A</div>
-    <div id="plus">A</div>
+    <div class="slidecontainer">
+      <input type="range" min="100" max="600" value="200" class="slider" id="font-size">
+    </div>
   </div>
 
   <script src="notes.js"></script>

--- a/notes.js
+++ b/notes.js
@@ -9,8 +9,7 @@
 const textarea = document.getElementById("textarea");
 const settings = document.getElementById("settings");
 const page = document.getElementById("page");
-const minus = document.getElementById("minus");
-const plus = document.getElementById("plus");
+const fontSize = document.getElementById("font-size");
 
 
 /* Placeholder */
@@ -31,28 +30,18 @@ const setFont = (font) => {
 
 /* Size */
 
-const minSize = 100;
-const maxSize = 600;
-let currentSize;
-
 const setSize = (size, store) => {
-  if (size < minSize || size > maxSize) {
-    return;
-  }
-  currentSize = size;
   textarea.style.fontSize = size + "%";
+  if (fontSize.value != size) {
+    fontSize.value = size;
+  }
   if (store) {
     chrome.storage.local.set({ size: size });
   }
 };
 
-minus.addEventListener("click", () => {
-  setSize(currentSize - 25, true);
-});
-
-plus.addEventListener("click", () => {
-  setSize(currentSize + 25, true);
-});
+fontSize.oninput = function () { setSize(this.value); };
+fontSize.onchange = function () { setSize(this.value, true); };
 
 
 /* Page */

--- a/notes.js
+++ b/notes.js
@@ -12,15 +12,6 @@ const page = document.getElementById("page");
 const fontSize = document.getElementById("font-size");
 
 
-/* Placeholder */
-
-const setPlaceholder = () => {
-  if (textarea.value === "") {
-    textarea.placeholder = "Type your notes here.";
-  }
-};
-
-
 /* Font */
 
 const setFont = (font) => {
@@ -95,7 +86,6 @@ chrome.storage.local.get(["index", "font", "size", "mode"], local => {
     currentIndex = local.index;
 
     setPage(currentNotes, currentIndex);
-    setPlaceholder();
   });
 
   setFont(local.font.fontFamily);
@@ -195,7 +185,6 @@ textarea.addEventListener("keyup", (event) => {
   }
 
   currentNotes[currentIndex] = textarea.value; // save notes locally
-  setPlaceholder();
   saveNotesDebounce(); // save notes to the storage
 });
 

--- a/options.js
+++ b/options.js
@@ -67,7 +67,7 @@ fontCheckboxes.forEach(checkbox => {
       fontFamily: [this.value, this.dataset.generic].join(',')
     };
 
-    chrome.storage.sync.set({ font: font });
+    chrome.storage.local.set({ font: font });
     setCurrentFontNameText(font.name);
   });
 });
@@ -76,14 +76,14 @@ modeCheckboxes.forEach(checkbox => {
   checkbox.addEventListener("click", function () {
     const mode = this.id;
     document.body.id = mode;
-    chrome.storage.sync.set({ mode: mode });
+    chrome.storage.local.set({ mode: mode });
   });
 });
 
 
 /* Storage */
 
-chrome.storage.sync.get(["font", "mode"], result => {
+chrome.storage.local.get(["font", "mode"], result => {
   // 1 FONT
   var currentFont = result.font; // see background.js
   var currentGeneric = currentFont.genericFamily;


### PR DESCRIPTION
## Use local storage

Use a combination of `chrome.storage.local` and `chrome.storage.sync` (before only sync).

**Store to Sync:**
- `notes`

**Store to Local:**
- `index`
- `font`
- `size`
- `mode`

This is a solution to https://github.com/penge/my-notes/issues/35

## Add slider

Use `range` HTML element (instead of **A** and **A**) to change the font size. It has these benefits:

1. code is more simple
2. change of font size is much more fluid and faster

## Fix placeholder

For some historical reasons due to CSS transition, placeholder was set via JS.
Now, placeholder is set as HTML attribute.
It makes code more simple and also fixes a bug due to which placeholder wasn't set on page change before.
