### PR TITLE
Migrate notes from 1.x and 2.x

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,9 +15,33 @@ const defaultFont = {
 const defaultSize = 200;
 const defaultMode = "light"; // "light", "dark"
 
-chrome.runtime.onInstalled.addListener(function () {
+const setNotes = (notes) => {
   chrome.storage.sync.set({
-    notes: defaultNotes
+    notes: notes
+  });
+};
+
+chrome.runtime.onInstalled.addListener(function () {
+  // Try to load notes from prior versions (order matters)
+  chrome.storage.sync.get(["newtab", "value", "notes"], sync => {
+    // 1.4, 1.3, 1.2
+    if (sync.value) {
+      setNotes([sync.value, "", ""]);
+      chrome.storage.sync.remove(["value", "newtab"]);
+
+    // 1.1.1, 1.1, 1.0
+    } else if (sync.newtab) {
+      setNotes([sync.newtab, "", ""]);
+      chrome.storage.sync.remove(["newtab"]);
+
+    // 2.x
+    } else if (sync.notes) {
+      setNotes(sync.notes);
+
+    // No prior version installed
+    } else {
+      setNotes(defaultNotes);
+    }
   });
 
   chrome.storage.local.set({

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "Chrome Extension that turns your \"New Tab\" into a note taking tool.",
-  "version": "2.0",
+  "version": "2.0.1",
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
   "permissions": ["storage"],

--- a/notes.js
+++ b/notes.js
@@ -41,7 +41,7 @@ let currentNotes;
 let currentIndex;
 
 const mergeNotes = (currentNotes) => {
-  const notesToSave = JSON.parse(localStorage.getItem('notesToSave'));
+  const notesToSave = JSON.parse(localStorage && localStorage.getItem('notesToSave'));
   if (!notesToSave) {
     return false;
   }
@@ -141,7 +141,7 @@ function isShift(event) {
 const saveNotes = (notes, flush) => {
   const notesToSave = mergeNotes(notes);
   if (!notesToSave) { return; }
-  if (flush) { localStorage.removeItem('notesToSave'); }
+  if (flush) { localStorage && localStorage.removeItem('notesToSave'); }
   currentNotes = notesToSave;
   chrome.storage.sync.set({ notes: notesToSave });
 };
@@ -207,9 +207,9 @@ textarea.addEventListener("keyup", (event) => {
     return;
   }
 
-  let notesToSave = JSON.parse(localStorage.getItem('notesToSave')) || [];
+  let notesToSave = JSON.parse(localStorage && localStorage.getItem('notesToSave')) || [];
   notesToSave[currentIndex] = textarea.value;
-  localStorage.setItem("notesToSave", JSON.stringify(notesToSave));
+  localStorage && localStorage.setItem("notesToSave", JSON.stringify(notesToSave));
 
   saveNotesDebounce(currentNotes);
 });


### PR DESCRIPTION
Migrate notes from **1.x** and **2.x.**

How are notes stored:

```
dd11009 - 2.0    (sync.notes: array)

bef71fd - 1.4    (sync.value: string)

c4af8a7 - 1.3    (sync.value: string)
48e6e40 - 1.2    (sync.value: string)

1328eb3 - 1.1.1  (sync.newtab: string)
baa5bc5 - 1.1    (sync.newtab: string)
508f211 - 1.0    (sync.newtab: string)
```

Migrate in this order:
- from `value` => `notes`
- from `newtab` => `notes`
- from `notes` => `notes`

After the migrate, delete the old keys (`value`, `newtab`).

Order (try to load `value` first, then `newtab`) matters, from most recent **1.x** to oldest **1.x.**
Reason: User might be having 1.2 which was previously updated from 1.1 but both keys (`value`, `newtab`) are present but only `value` is relevant.

This is a solution to https://github.com/penge/my-notes/issues/41
