### PR TITLE
Fix context menu listener, Add focus listener

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,29 +45,6 @@ const createContextMenu = () => {
       contexts: ["selection"],
     });
   });
-
-  chrome.contextMenus.onClicked.addListener((info) => {
-    const { pageUrl, selectionText } = info;
-    const textToSave = `// ${pageUrl}\r\n${selectionText}\r\n\r\n`;
-
-    if (info.menuItemId === "my-notes-save") {
-      chrome.storage.local.get(["notes"], local => {
-        const notes = local.notes;
-        notes[0] = textToSave + notes[0];
-        chrome.storage.local.set({ notes: notes });
-      });
-    }
-
-    if (info.menuItemId === "my-notes-send") {
-      chrome.storage.local.get(["token"], local => {
-        const selection = {
-          text: textToSave,
-          sender: local.token,
-        };
-        chrome.storage.sync.set({ selection: selection });
-      });
-    }
-  });
 };
 
 chrome.runtime.onInstalled.addListener(() => {
@@ -107,3 +84,25 @@ chrome.runtime.onInstalled.addListener(() => {
   createContextMenu();
 });
 
+chrome.contextMenus.onClicked.addListener((info) => {
+  const { pageUrl, selectionText } = info;
+  const textToSave = `// ${pageUrl}\r\n${selectionText}\r\n\r\n`;
+
+  if (info.menuItemId === "my-notes-save") {
+    chrome.storage.local.get(["notes"], local => {
+      const notes = local.notes;
+      notes[0] = textToSave + notes[0];
+      chrome.storage.local.set({ notes: notes });
+    });
+  }
+
+  if (info.menuItemId === "my-notes-send") {
+    chrome.storage.local.get(["token"], local => {
+      const selection = {
+        text: textToSave,
+        sender: local.token,
+      };
+      chrome.storage.sync.set({ selection: selection });
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "Chrome Extension that turns your \"New Tab\" into a note taking tool.",
-  "version": "2.2",
+  "version": "2.2.1",
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
   "permissions": ["storage", "contextMenus"],

--- a/options.js
+++ b/options.js
@@ -35,7 +35,7 @@ const modeRadios = document.getElementsByName("mode");
 
 /* Focus elements */
 
-const focusRadio = document.getElementById("focus");
+const focusCheckbox = document.getElementById("focus");
 
 
 /* Helpers */
@@ -101,7 +101,7 @@ modeRadios.forEach(radio => {
   });
 });
 
-focusRadio.addEventListener("click", function () {
+focusCheckbox.addEventListener("click", function () {
   chrome.storage.local.set({ focus: this.checked });
 })
 
@@ -131,7 +131,16 @@ chrome.storage.local.get(["font", "size", "mode", "focus"], local => {
   document.body.id = local.mode;
 
   // 4 FOCUS
-  focusRadio.checked = local.focus;
+  focusCheckbox.checked = local.focus;
+});
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName === "local") {
+    if (changes["focus"]) {
+      const focus = changes["focus"].newValue;
+      focusCheckbox.checked = focus;
+    }
+  }
 });
 
 })(); // IIFE


### PR DESCRIPTION
**Changes:**

- Fix context menu listener so it works when background is enabled/disabled/enabled.

- Add focus listener so Options page "focus" checkbox is updated when pressed keyboard shortcut to toggle focus (either from Options page or My Notes page)