### PR TITLE
Remove New Tab replacement, Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ My Notes is a Chrome Extension that turns your **New Tab** into a note-taking to
 
 - Great for Notes, Todos, and sharing text (Copy/Paste)
 
-- It works immediately after you open a **New Tab**
+- It works immediately after you click My Notes icon (located in toolbar)
 
 - Every edit and paste is saved (and waiting for you once you come back)
 
@@ -16,10 +16,10 @@ My Notes is a Chrome Extension that turns your **New Tab** into a note-taking to
 
 ![My Notes](image.png)
 
-My Notes can be open with **1 click on the icon**, or it can replace New Tab if set by **Options**.
+My Notes can be open with **1 click on the icon.**
 
-Font in the picture above is **Courier Prime** and is available via **Google Fonts**.
-Font can be easily changed in **Options**.
+Font in the picture above is **Courier Prime** and is available via **Google Fonts.**
+Font can be easily changed in **Options.**
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ Font can be easily changed in **Options.**
 
 <br>
 
+## Options
+
+Options can be open with a click on Options link (in the bottom panel of My Notes),
+or with a right-click on My Notes icon (in the browser's toolbar) and selecting Options.
+
+**Options allow you to:**
+
+- set Font type (Serif, Sans Serif, Monospace, Google Fonts)
+- set Font size (using the slider)
+- change the color mode (light mode or dark mode)
+- see Keyboard Shortcuts that you may use (Windows, Linux, Mac)
+- set Focus mode (can be set explicitly using the checkbox, or can be also changed with a keyboard shortcut)
+- see the ways of contacting me if needed
+- see the installed version number
+
+<br>
+
 ## Context menu
 
 After selecting a text on a website, you can use the context menu (right click)
@@ -65,3 +82,25 @@ My Notes can be installed manually:
 3. In Chrome, go to **Extensions** from the menu or visit [chrome://extensions](chrome://extensions) from a new tab
 4. In Chrome Extensions, click the **"Load unpacked"** button
 5. Navigate to the plugin folder (from the second step) and click the **"Open"** button
+
+<br>
+
+## Storage
+
+My Notes are stored in your browser using `Chrome Storage Local` and `Chrome Storage Sync`.
+`localStorage` is used to optimize saving.
+
+If you accidentally uninstall My Notes extension, data will be lost. Consider doing a backup first.
+
+In future, My Notes can be stored in Google Drive which is a higly anticipated feature.
+This would allow to have remote backups and revisions.
+
+<br>
+
+## Permissions
+
+As My Notes is an extension, it relies on permissions that must be granted by you in order to work.
+
+My Notes relies on very simple permissions that are called "storage" and "contextMenus".
+As their name suggests, "storage" permission is required to save My Notes using Chrome Storage.
+The second one, "contextMenus", is a permission used to create Context menu.

--- a/background.js
+++ b/background.js
@@ -15,7 +15,6 @@ const defaultFont = {
 const defaultSize = 150;
 const defaultMode = "light"; // "light", "dark"
 const defaultFocus = false;
-const defaultOverride = true;
 
 const getRandomToken = () => {
   const randomPool = new Uint8Array(32);
@@ -69,14 +68,13 @@ chrome.runtime.onInstalled.addListener(() => {
     });
   });
 
-  chrome.storage.local.get(["index", "font", "size", "mode", "focus", "override"], local => {
+  chrome.storage.local.get(["index", "font", "size", "mode", "focus"], local => {
     chrome.storage.local.set({
       index: (local.index !== "undefined" ? local.index : defaultIndex),
       font: (local.font || defaultFont),
       size: (local.size || defaultSize),
       mode: (local.mode || defaultMode),
       focus: (local.focus !== "undefined" ? local.focus : defaultFocus),
-      override: (local.override !== "undefined" ? local.override : defaultOverride),
     });
   });
 
@@ -111,18 +109,6 @@ chrome.contextMenus.onClicked.addListener((info) => {
 
 chrome.browserAction.onClicked.addListener(() => {
   chrome.tabs.create({ url: "/notes.html" });
-});
-
-chrome.tabs.onCreated.addListener((tab) => {
-  chrome.storage.local.get(["override"], local => {
-    if (!local.override) {
-      return;
-    }
-    // pendingUrl available since Chrome 79; use url as fallback
-    if (tab.pendingUrl === "chrome://newtab/" || tab.url === "chrome://newtab/") {
-      chrome.tabs.update(tab.id, { url: "/notes.html" });
-    }
-  });
 });
 
 chrome.runtime.onInstalled.addListener((details) => {

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "2.3",
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
-  "permissions": ["storage", "contextMenus", "tabs"],
+  "permissions": ["storage", "contextMenus"],
   "background": {
     "scripts": ["debounce.js", "background.js"],
     "persistent": false

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "Turn your New Tab into a note-taking tool.",
-  "version": "2.3",
+  "version": "2.3.1",
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
   "permissions": ["storage", "contextMenus"],

--- a/options.css
+++ b/options.css
@@ -29,9 +29,10 @@ input, select {
 
 .comment {
   font-size: 80%;
-  padding-top: 30px;
-  line-height: 150%;
+  font-weight: normal;
+  font-style: italic;
   color: #9E9E9E;
+  user-select: none;
 }
 
 .separator {
@@ -187,6 +188,18 @@ input, select {
 .shortcut {
   font-weight: bold;
   padding-right: 20px;
+}
+
+
+/* Options */
+
+#options .selection {
+  display: flex;
+  align-items: baseline;
+}
+
+#options .selection .comment {
+  padding: 10px 8px;
 }
 
 

--- a/options.html
+++ b/options.html
@@ -118,16 +118,6 @@
         </div>
       </div>
     </div>
-    <div class="selection">
-      <input type="checkbox" id="override" name="override">
-      <div>
-        <label for="override" class="heavy">Replace New Tab</label>
-        <div class="comment">
-          My Notes can always be open with 1 click on the icon in browser's toolbar.<br>
-          Replace New Tab opens My Notes in every New Tab.
-        </div>
-      </div>
-    </div>
   </div>
 
 

--- a/options.html
+++ b/options.html
@@ -80,7 +80,7 @@
       </tr>
       <tr>
         <td class="shortcut">Ctrl + Shift + F</td>
-        <td>Toggle focus mode</td>
+        <td>Toggle Focus mode</td>
       </tr>
     </table>
     <h3>Mac</h3>
@@ -99,21 +99,34 @@
       </tr>
       <tr>
         <td class="shortcut">Option + F</td>
-        <td>Toggle focus mode</td>
+        <td>Toggle Focus mode</td>
       </tr>
     </table>
   </div>
 
 
   <h2>Options</h2>
-  <div>
+  <div id="options">
     <div class="selection">
       <input type="checkbox" id="focus" name="focus">
-      <label for="focus" class="heavy">Focus by default</label>
+      <div>
+        <label for="focus" class="heavy">Focus mode</label>
+        <div class="comment">
+          Focus mode hides bottom panel (Options link and page number) to give you more editing space.<br>
+          To change this option back, visit Options (right-click on My Notes icon in browser's toolbar),
+          or press "Toggle Focus mode" keyboard shortcut.
+        </div>
+      </div>
     </div>
     <div class="selection">
       <input type="checkbox" id="override" name="override">
-      <label for="override" class="heavy">Replace New Tab</label>
+      <div>
+        <label for="override" class="heavy">Replace New Tab</label>
+        <div class="comment">
+          My Notes can always be open with 1 click on the icon in browser's toolbar.<br>
+          Replace New Tab opens My Notes in every New Tab.
+        </div>
+      </div>
     </div>
   </div>
 

--- a/options.js
+++ b/options.js
@@ -105,7 +105,6 @@ const currentSize = document.getElementById("current-size");
 const modeRadios = document.getElementsByName("mode");
 
 const focusCheckbox = document.getElementById("focus");
-const overrideCheckbox = document.getElementById("override");
 
 
 /* Helpers */
@@ -213,10 +212,6 @@ focusCheckbox.addEventListener("click", function () {
   chrome.storage.local.set({ focus: this.checked });
 });
 
-overrideCheckbox.addEventListener("click", function () {
-  chrome.storage.local.set({ override: this.checked });
-});
-
 
 /* Storage helpers */
 
@@ -245,20 +240,15 @@ const applyFocus = (focus) => {
   focusCheckbox.checked = focus;
 };
 
-const applyOverride = (override) => {
-  overrideCheckbox.checked = override;
-};
-
 
 /* Storage */
 
-chrome.storage.local.get(["font", "size", "mode", "focus", "override"], local => {
-  const { font, size, mode, focus, override } = local;
+chrome.storage.local.get(["font", "size", "mode", "focus"], local => {
+  const { font, size, mode, focus } = local;
   applyFont(font);
   applySize(size);
   applyMode(mode);
   applyFocus(focus);
-  applyOverride(override);
 });
 
 const apply = (change, applyHandler) => {
@@ -271,7 +261,6 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
     apply(changes["size"], applySize);
     apply(changes["mode"], applyMode);
     apply(changes["focus"], applyFocus);
-    apply(changes["override"], applyOverride);
   }
 });
 


### PR DESCRIPTION
This is a patch version **2.3.1** with following changes:

1) New Tab replacement is removed. A preffered way to open My Notes is with 1 click on the icon.
2) README is updated and describes Options, Storage, Permissions.
3) Description added to "Focus mode" checkbox (which was previously called "Focus by default")

Related issues:

- https://github.com/penge/my-notes/issues/57
- https://github.com/penge/my-notes/issues/60
- https://github.com/penge/my-notes/issues/61