### PR TITLE
Bring back "Open in every new tab"

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: penge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing
+
+Here are some ways how you can support My Notes and help me to make it better.
+
+<br>
+
+## Feedback
+
+> _I would like to have (or no have) feature ABC._
+>
+> _This is great. Thank you!_
+>
+> _Can we change this?_
+>
+> _This isn't very clear. What is it?_
+>
+> Hey, I think I found a mistake.
+>
+> Wow! This is really simple!
+
+Good or bad feedback is ok. Don't think about it much.
+
+Feedback is important to understand what you would like to see or have changed.
+
+<br>
+
+## Testing
+
+Testing helps to eliminate mistakes and to bring better quality and compatibility.
+
+If you would like, you can help me to test an upcoming version of My Notes before it gets released.
+
+<br>
+
+## English
+
+> _Oh. Here's a typo!_
+>
+> _I am a native English. Bring it on!_
+>
+> _This paragraph is better to write like this._
+
+If you spot something that can be written in a better way, please, let me know.
+
+<br>
+
+## Design
+
+> _Look! This icon is perfect!_
+>
+> _How about this banner I made?_
+>
+> _How about using this color?_
+>
+> _I have made a new template/layout._
+
+If you are a designer, there is always an opportunity to make things more nice and sleek!
+
+<br>
+
+## Development
+
+> _I have found a bug/improvement. Here's my PR!_
+>
+> _I am new to this but still would like to help/learn. Can you find something for me?_
+
+If you are new or experienced, I would try to find ways how to work together.
+
+<br>
+
+## Donations
+
+GitHub Sponsor is a way how you can support my work. The "Sponsor" button is located at the top.

--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,0 +1,20 @@
+# Permissions
+
+My Notes needs permissions to provide the required functionality.
+
+These permissions are listed in [**manifest.json**](manifest.json):
+
+- **"storage"** – required to save notes and options (font type, font size, etc.) to Chrome Storage
+
+- **"contextMenus"** – required to create Context menu
+
+- **"tabs"** – required to open My Notes in every new tab, if enabled
+
+Among these permissions, **"tabs"** requires to be granted when you click
+**"Open in every new tab"** in Options.
+
+Because **"tabs"** is a more powerful permission, the displayed warning
+may contain an unrelated message – `It can: Read your Browsing history`.
+
+Do not panic. My Notes really doesn't read your browsing history.
+The message just comes with the permission and cannot be changed.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # My Notes
 
-My Notes is a Chrome Extension that turns your **New Tab** into a note-taking tool.
+**My Notes** is a _Chrome Extension_ that turns your **New Tab** into a note-taking app.
 
-- Great for Notes, Todos, and sharing text (Copy/Paste)
+- It is great for writing down notes, todos, thoughts, and adding a temporary text (Copy/Paste)
 
-- It works immediately after you click My Notes icon (located in toolbar)
+- It works immediately after you click My Notes icon (located in the browser's toolbar)
+and it can be open in every new tab if enabled (see **Options**)
 
-- Every edit and paste is saved (and waiting for you once you come back)
+- Every edit and paste is saved and ready when you come back
 
-- And! It is Synchronized across every Chrome window you have open
+- Every edit is synchronized in other windows you have open
+
+- **Context menu** can be used to send a text to your other computers if using
+the same Google Account and having My Notes open
 
 <br>
 
@@ -16,17 +20,17 @@ My Notes is a Chrome Extension that turns your **New Tab** into a note-taking to
 
 ![My Notes](image.png)
 
-My Notes can be open with **1 click on the icon.**
+My Notes can be open with 1 click on the icon (located in the browser's toolbar)
+or it can be open in every new tab if enabled (see **Options**).
 
-Font in the picture above is **Courier Prime** and is available via **Google Fonts.**
-Font can be easily changed in **Options.**
+The font used in the picture above is **Courier Prime**, available via **Google Fonts**.
+See **Options** to change the font.
 
 <br>
 
 ## Options
 
-Options can be open with a click on Options link (in the bottom panel of My Notes),
-or with a right-click on My Notes icon (in the browser's toolbar) and selecting Options.
+Options can be open with a click on Options link (in the bottom panel of My Notes), or with a right-click on My Notes icon (in the browser's toolbar) and selecting Options.
 
 **Options allow you to:**
 
@@ -34,27 +38,25 @@ or with a right-click on My Notes icon (in the browser's toolbar) and selecting 
 - set Font size (using the slider)
 - change the color mode (light mode or dark mode)
 - see Keyboard Shortcuts that you may use (Windows, Linux, Mac)
-- set Focus mode (can be set explicitly using the checkbox, or can be also changed with a keyboard shortcut)
-- see the ways of contacting me if needed
-- see the installed version number
+- enable Focus mode (can be enabled with a checkbox, or toggled with a keyboard shortcut)
+- open My Notes in every new tab if granted (see [**Permissions**](PERMISSIONS.md))
+- see the version number and what's new
+- see the important resources – Support, Contributing, Permissions, Repository
 
 <br>
 
 ## Context menu
 
-After selecting a text on a website, you can use the context menu (right click)
-to save the selection to My Notes.
+After selecting a text on a website, you can right-click and use My Notes Context menu to save the selection to My Notes.
 
 <br>
 
 ![Context Menu](context-menu.png)
 
-
 Available options:
 
-- **Save selection** to save the selection to your computer
-- **Save selection to other devices** to save the selection to your other computer(s)
-where you are logged in with the same Google Account
+- **Save selection** to save the selection to My Notes in the current computer
+- **Save selection to other devices** to save the selection to My Notes in your other computer(s) where you are logged-in under the same Google Account and have My Notes open
 
 <br>
 
@@ -87,20 +89,27 @@ My Notes can be installed manually:
 
 ## Storage
 
-My Notes are stored in your browser using `Chrome Storage Local` and `Chrome Storage Sync`.
-`localStorage` is used to optimize saving.
+My Notes is stored in:
 
-If you accidentally uninstall My Notes extension, data will be lost. Consider doing a backup first.
+- **Chrome Storage**, which comes down to:
+  - **Chrome Storage Local** as a storage for notes and options (font type, font size, etc.), limited to 5MB
+  - **Chrome Storage Sync** as a storage for the text saved by My Notes Context Menu -> **Save selection to other devices**, limited to 100KB
 
-In future, My Notes can be stored in Google Drive which is a higly anticipated feature.
-This would allow to have remote backups and revisions.
+- **localStorage** to optimize the saving of notes
+
+Notes are saved every **1 second** if changed.
+
+If you accidentally uninstall My Notes extension and don't have a backup, data will be lost.
+Consider doing a backup first.
+
+Version 3.0 will introduce **Google Drive** backup as a prevention to data loss.
+If enabled, My Notes can have an ongoing backup to your Google Drive.
 
 <br>
 
-## Permissions
+## Resources
 
-As My Notes is an extension, it relies on permissions that must be granted by you in order to work.
-
-My Notes relies on very simple permissions that are called "storage" and "contextMenus".
-As their name suggests, "storage" permission is required to save My Notes using Chrome Storage.
-The second one, "contextMenus", is a permission used to create Context menu.
+- [**Support**](SUPPORT.md)
+- [**Contributing**](CONTRIBUTING.md)
+- [**Permissions**](PERMISSIONS.md)
+- **Repository** – you are right here

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+# Support
+
+If you need any help, consider first:
+
+- [**README**](README.md) – see if the answer is there
+- [**Issues**](https://github.com/penge/my-notes/issues) – see if the issue was reported and if not, create a new one
+
+<br>
+
+### Slack
+
+Join Slack channel, where we can chat. The link is **http://bit.ly/hellopenge**
+
+<br>
+
+### Email
+
+My email address is **<bucka.pavel@gmail.com>**

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
   "permissions": ["storage", "contextMenus"],
+  "optional_permissions": ["tabs"],
   "background": {
     "scripts": ["debounce.js", "background.js"],
     "persistent": false

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 2,
   "name": "My Notes",
-  "description": "Turn your New Tab into a note-taking tool.",
-  "version": "2.3.2",
+  "description": "Turn your New Tab into a note-taking app.",
+  "version": "2.4",
+  "homepage_url": "https://github.com/penge/my-notes",
   "icons": { "128": "icon128.png" },
   "options_page": "options.html",
   "permissions": ["storage", "contextMenus"],

--- a/options.css
+++ b/options.css
@@ -47,12 +47,12 @@ input, select {
   display: none !important;
 }
 
-#contact, #see-whats-new {
+a {
   font-weight: bold;
   text-decoration: underline;
 }
 
-#see-whats-new {
+a#see-whats-new {
   margin-left: 1em;
 }
 

--- a/options.css
+++ b/options.css
@@ -31,8 +31,8 @@ input, select {
   font-size: 80%;
   font-weight: normal;
   font-style: italic;
-  color: #9E9E9E;
   user-select: none;
+  opacity: .8;
 }
 
 .separator {
@@ -193,13 +193,13 @@ input, select {
 
 /* Options */
 
-#options .selection {
+.selection.with-comment {
   display: flex;
   align-items: baseline;
 }
 
-#options .selection .comment {
-  padding: 10px 8px;
+.selection .comment {
+  padding: 12px 8px 20px 8px;
 }
 
 

--- a/options.html
+++ b/options.html
@@ -143,15 +143,21 @@
   </div>
 
 
-  <h2>Support</h2>
-  <p><span id="contact">bucka.pavel@gmail.com</span></p>
-
-
   <h2>Version</h2>
   <p>
     <strong id="version"></strong>
     <a id="see-whats-new" href="https://github.com/penge/my-notes/releases" target="_blank">See what's new</a>
   </p>
+
+
+  <h2>Resources</h2>
+  <div>
+    <a href="https://github.com/penge/my-notes/blob/master/SUPPORT.md" target="_blank">Support</a>
+    <a href="https://github.com/penge/my-notes/blob/master/CONTRIBUTING.md" target="_blank">Contributing</a>
+    <a href="https://github.com/penge/my-notes/blob/master/PERMISSIONS.md" target="_blank">Permissions</a>
+    <a href="https://github.com/penge/my-notes" target="_blank">Repository</a>
+  </div>
+
 
   <script src="options.js"></script>
 </body>

--- a/options.html
+++ b/options.html
@@ -128,6 +128,18 @@
         </div>
       </div>
     </div>
+    <div class="selection with-comment">
+      <input type="checkbox" id="backup" name="backup" disabled="disabled">
+      <div>
+        <label for="backup" class="heavy">Backup to Google Drive (coming in My Notes 3.0)</label>
+        <div class="comment">
+          Creates and maintains a backup of My Notes in your Google Drive under the folder My Notes.<br>
+          A permission will be requested during the process.<br>
+          If there is a backup left by a previous installation, it will be used.
+          If you had some local notes already, they will be added to the backup.
+        </div>
+      </div>
+    </div>
   </div>
 
 

--- a/options.html
+++ b/options.html
@@ -106,15 +106,25 @@
 
 
   <h2>Options</h2>
-  <div id="options">
-    <div class="selection">
+  <div>
+    <div class="selection with-comment">
       <input type="checkbox" id="focus" name="focus">
       <div>
         <label for="focus" class="heavy">Focus mode</label>
         <div class="comment">
           Focus mode hides bottom panel (Options link and page number) to give you more editing space.<br>
-          To change this option back, visit Options (right-click on My Notes icon in browser's toolbar),
+          To change this back, visit Options (right-click on My Notes icon in the browser's toolbar),
           or press "Toggle Focus mode" keyboard shortcut.
+        </div>
+      </div>
+    </div>
+    <div class="selection with-comment">
+      <input type="checkbox" id="newtab" name="newtab">
+      <div>
+        <label for="newtab" class="heavy">Open in every new tab</label>
+        <div class="comment">
+          If enabled, My Notes will be open in every new tab.<br>
+          A permission will be requested during the process.
         </div>
       </div>
     </div>

--- a/options.js
+++ b/options.js
@@ -105,6 +105,7 @@ const currentSize = document.getElementById("current-size");
 const modeRadios = document.getElementsByName("mode");
 
 const focusCheckbox = document.getElementById("focus");
+const newtabCheckbox = document.getElementById("newtab");
 
 
 /* Helpers */
@@ -212,6 +213,23 @@ focusCheckbox.addEventListener("click", function () {
   chrome.storage.local.set({ focus: this.checked });
 });
 
+newtabCheckbox.addEventListener("click", function () {
+  if (newtabCheckbox.checked) {
+    chrome.permissions.request({ permissions: ["tabs"] }, granted => {
+      newtabCheckbox.checked = granted;
+      chrome.storage.local.set({ newtab: granted });
+    });
+    return;
+  }
+
+  chrome.permissions.remove({ permissions: ["tabs"] }, removed => {
+    if (removed) {
+      newtabCheckbox.checked = false;
+      chrome.storage.local.set({ newtab: false });
+    }
+  });
+});
+
 
 /* Storage helpers */
 
@@ -240,15 +258,20 @@ const applyFocus = (focus) => {
   focusCheckbox.checked = focus;
 };
 
+const applyNewtab = (newtab) => {
+  newtabCheckbox.checked = newtab;
+};
+
 
 /* Storage */
 
-chrome.storage.local.get(["font", "size", "mode", "focus"], local => {
-  const { font, size, mode, focus } = local;
+chrome.storage.local.get(["font", "size", "mode", "focus", "newtab"], local => {
+  const { font, size, mode, focus, newtab } = local;
   applyFont(font);
   applySize(size);
   applyMode(mode);
   applyFocus(focus);
+  applyNewtab(newtab);
 });
 
 const apply = (change, applyHandler) => {
@@ -261,6 +284,7 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
     apply(changes["size"], applySize);
     apply(changes["mode"], applyMode);
     apply(changes["focus"], applyFocus);
+    apply(changes["newtab"], applyNewtab);
   }
 });
 

--- a/options.js
+++ b/options.js
@@ -121,6 +121,12 @@ function checkById(id) {
   if (element) { element.checked = true; }
 }
 
+function uncheckAll(radios) {
+  for (const radio of radios) {
+    radio.checked = false;
+  };
+}
+
 function displayFontCategory(id) {
   for (const category of fontCategories) {
     category.classList.toggle("active", category.id === id);
@@ -183,9 +189,10 @@ submit.addEventListener("click", function () {
       fontFamily: fontFamily, // '"Roboto Mono"'
       href: fontHref,
     };
+    uncheckAll(fontRadios);
+    setCurrentFontNameText(font);
     submit.value= "Applied";
     chrome.storage.local.set({ font: font });
-    setCurrentFontNameText(font);
   })
   .catch(() => {
     submit.classList.remove("active");


### PR DESCRIPTION
My Notes 2.4 can be again open in every new tab if enabled. This was removed before in 2.3.1 due to the reasons you can read about in [**Releases**](https://github.com/penge/my-notes/releases/tag/2.3.1).

To have My Notes open in every new tab, visit Options and check **"Open in every new tab"**.

Using the same permission as before – **"tabs"** – needed to open My Notes in every new tab. This time, the permission is optional, meaning it needs to be approved first.
When you check **"Open in every new tab"** for the first time, a popup requesting the permission will be shown.

The popup will contain an unrelated message but that's ok.
See a new document called **Permissions** where everything is explained.

<br>

Besides bringing back **"Open in every new tab"**, the next changes are:

- **README** is updated

- `manifest.json` is updated

- New documents are added – **Support**, **Contributing**, **Permissions**

- GitHub Sponsor is added

- After setting Google Font in Options, previously checked font radio button is unchecked as expected

- Options have a new section regarding the upcoming Google Drive support that will be available in My Notes 3

<br>

I hope you'll like the changes :)