### PR TITLE
Fix text wrapping

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "My Notes — Chrome extension for note-taking in a New Tab.",
-  "version": "3.0",
+  "version": "3.0.1",
   "homepage_url": "https://github.com/penge/my-notes",
   "icons": { "128": "images/icon128.png" },
   "options_page": "options.html",

--- a/notes.css
+++ b/notes.css
@@ -123,6 +123,12 @@ hr {
   justify-content: space-between;
 }
 
+#content, .note-tile .note-content {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
 #content {
   width: 100%;
   height: 100%;
@@ -133,10 +139,6 @@ hr {
   font-family: inherit;
   font-size: inherit;
   padding: 1em;
-  white-space: pre;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  white-space: normal;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
Fixes wrapping on newline characters.

Using `pre-wrap` (https://developer.mozilla.org/en-US/docs/Web/CSS/white-space)

<br>

Closes https://github.com/penge/my-notes/issues/84
Thanks to @JeromeDeLeon  for finding the solution! And to @wbeirigo for reporting!