### PR TITLE
Remove autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 <br>
 
-**My Notes** — Note-taking in a New Tab. Simple. Fast. Available on [_Web Store_](https://chrome.google.com/webstore/detail/my-notes/lkeeogfaiembcblonahillacpaabmiop).
+**My Notes** — Chrome extension for simple note taking.
+Available on [_Web Store_](https://chrome.google.com/webstore/detail/my-notes/lkeeogfaiembcblonahillacpaabmiop).
 
 <br>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "My Notes",
-  "description": "Note-taking in a New Tab. Simple. Fast.",
-  "version": "3.0.3",
+  "description": "Simple note taking.",
+  "version": "3.0.4",
   "homepage_url": "https://github.com/penge/my-notes",
   "icons": { "128": "images/icon128.png" },
   "options_page": "options.html",

--- a/notes/view/set-active.js
+++ b/notes/view/set-active.js
@@ -10,14 +10,8 @@ export default function setActive(name, html, { renameNote, deleteNote }) {
   noteName.innerText = name;
   noteName.classList.toggle("reserved", isReserved(name));
 
-  content.style.caretColor = "transparent";
   content.innerHTML = html;
-  setTimeout(function() {
-    content.focus();
-    document.execCommand("selectAll", false, null);
-    document.getSelection().collapseToEnd();
-    content.style.caretColor = "";
-  }, 0);
+  content.blur();
 
   attachOptions(name, { noteOptions, renameNote, deleteNote });
 }


### PR DESCRIPTION
Autofocus support has to be removed. (Closes https://github.com/penge/my-notes/issues/91)

**Reason:** Inconsistent and unpredictable behavior on `CTRL + T` caused by the keyboard not having a guaranteed focus. This has no solution as this is a behavior of Chrome.