### PR TITLE
Fix unselected address bar

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   },
   "background": {
     "page": "background.html",
-    "persistent": false
+    "persistent": true
   },
   "browser_action": {
     "default_icon": "images/icon128.png"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "Simple note taking.",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "homepage_url": "https://github.com/penge/my-notes",
   "icons": { "128": "images/icon128.png" },
   "options_page": "options.html",

--- a/notes/view/set-active.js
+++ b/notes/view/set-active.js
@@ -1,4 +1,4 @@
-/* global document, setTimeout */
+/* global document */
 
 import { noteName, noteOptions, content } from "./elements.js";
 import { isReserved } from "../reserved.js";
@@ -11,7 +11,6 @@ export default function setActive(name, html, { renameNote, deleteNote }) {
   noteName.classList.toggle("reserved", isReserved(name));
 
   content.innerHTML = html;
-  content.blur();
 
   attachOptions(name, { noteOptions, renameNote, deleteNote });
 }


### PR DESCRIPTION
In Windows and OSX, if the extension was unloaded and therefore set as **"Innactive"** (you can see this in `chrome://extensions`), the address bar would not be selected on `CTRL + T`, as it should. This happened on the first open only and further openings were without problems.

If the first action would be to open **Options** instead, and then My Notes would be open with `CTRL + T`, the problem wouldn't happen.

The only explanation to this behavior is, that the internally used `chrome.tabs.update` is having problems if background page isn't fully loaded first (after it was **"Innactive"**).

This problem doesn't happen in Chrome OS. There, event-driven background page (not persistent), that is **"Innactive"**, doesn't cause any trouble on `CTRL + T`.

I am setting background page as **persistent**, which is the only solution at this point.

Closes https://github.com/penge/my-notes/issues/91