### PR TITLE
Save note on Spellcheck fix, update design and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
-![My Notes](images/my-notes.png)
+<p align="center"></p>
+<h1 align="center">My Notes — <a href="https://chrome.google.com/webstore/detail/my-notes/lkeeogfaiembcblonahillacpaabmiop">Web Store</a></h1>
+<p align="center">
+  <img src="https://badgen.net/github/release/penge/my-notes" />
+  <img src="https://badgen.net/github/license/penge/my-notes" />
+  <img src="https://badgen.net/chrome-web-store/users/lkeeogfaiembcblonahillacpaabmiop" />
+  <br><br>
+  <img src="images/my-notes.png" width="800" /><br>
+  My Notes is a Chrome extension for simple and fast note-taking.<br><br>
+  Write down your ideas, notes, todos, clipboard, articles, and other, all effortlessly in a Chrome's New Tab.
+</p>
 
-**My Notes** is a note-taking app directly in Chrome.
-Available on [Web Store](https://chrome.google.com/webstore/detail/my-notes/lkeeogfaiembcblonahillacpaabmiop).
+<br><br>
 
 ## Features
 
-- Quickly accessible (see [How to open](#how-to-open))
+→ &nbsp; All notes available inside your Chrome ([_How to open_](#how-to-open))
 
-- Saved automatically
+→ &nbsp; All notes saved automatically
 
-- Updated in every open window
+→ &nbsp; All notes synchronized in every open window as you edit them
 
-- HTML (bold, italic, underline, etc.)
+→ &nbsp; Can use HTML
 
-- Transfer text to another computer (see [Context menu](#context-menu))
+→ &nbsp; Great as a Clipboard
 
-- Google Drive Sync, to backup, share, and sync the notes between computers (see [Google Drive Sync](#google-drive-sync))
+→ &nbsp; Can send text between computers ([_Context menu_](#context-menu))
 
-- Themes (Light, Dark, Custom)
+→ &nbsp; Can store notes to Google Drive and edit them from other devices ([_Google Drive Sync_](#google-drive-sync))
 
-- Hotkeys
+→ &nbsp; Themes (Light, Dark, Custom)
 
-- Works offline
+→ &nbsp; Hotkeys
+
+→ &nbsp; Works offline
 
 <br>
 
@@ -29,70 +40,68 @@ Available on [Web Store](https://chrome.google.com/webstore/detail/my-notes/lkee
 
 **My Notes:**
 
-- Click on My Notes icon in Chrome toolbar
-- In every new tab (see Options)
-- Hotkey (see Options)
+<ol type="A">
+  <li>Click on My Notes icon in Chrome toolbar</li>
+  <li>In every new tab (see Options)</li>
+  <li>Use Hotkey (see Options)</li>
+</ol>
 
 **Options:**
 
-- Click on the gear icon
-- Right-click on My Notes icon in Chrome toolbar and select Options
-- Hotkey (see Options)
+<ol type="A">
+  <li>Click on the gear icon in the bottom left corner</li>
+  <li>Right-click on My Notes icon in the Chrome toolbar and select Options</li>
+  <li>Use Hotkey (see Options)</li>
+</ol>
 
-<br>
-
-## Options
-
-- Font type (Serif, Sans Serif, Monospace, Google Fonts)
-- Font size
-- Theme (Light, Dark, Custom)
-- Hotkeys
-- Open My Notes in every New Tab
-- Enable Google Drive Sync
-- Indent text on Tab
-
-<br>
+<br><br>
 
 ## Context menu
 
-Allows you to quickly save the selected text to My Notes Clipboard (a special note in My Notes).
+Context menu allows you to quickly save the selected text to My Notes Clipboard (a special note in My Notes).
 
-![Context menu](images/context-menu.png)
+<img src="images/context-menu.png" width="800" />
 
-**Save selection** — Saves the selected text to My Notes Clipboard in your current computer.
+### Save selection
 
-**Save selection to other devices** — Saves the selected text to My Notes Clipboard in your other computer(s).
-**Condition:** My Notes needs to be open, same Google Account needs to be used.
+Saves the selected text to My Notes Clipboard in your current computer.
+My Notes doesn't have to be open.
 
-<br>
+### Save selection to other devices
+
+Saves the selected text to My Notes Clipboard in your other computer(s).
+My Notes needs to be open in the second computer and same Google Account needs to be used.
+
+<br><br>
 
 ## Google Drive Sync
 
-**Google Drive Sync** automatically syncs your notes between My Notes and your Google Drive, in both directions (from Google Drive, to Google Drive).
+Google Drive Sync (see Options) saves your notes to Google Drive and synchronizes the changes between your local My Notes and your Google Drive
+every time you hit the Sync button (bottom left corner).
 
-This gives you:
+Benefits:
 
-- a backup (notes can be restored in the future)
-- can modify the notes in Google Drive, My Notes, and vice versa
-- can modify the notes from other computers (by installing My Notes and using the same Google Account)
+- backup of notes in your Google Drive
+- notes can be restored in the future if My Notes is re-installed, by re-enabling Google Drive Sync
+- notes can be edited from Google Drive if needed (or from other devices that have access to Google Drive)
+- notes can be edited from other computers where My Notes is installed and Google Drive Sync is enabled (using same Google Account is needed)
 
 ### Location
 
 Notes are uploaded to your Google Drive to the folder **My Notes**. This folder is created automatically.
-If the folder exists from a previous installation, it is restored, notes are downloaded and uploaded, and the synchronization continues.
+If the folder exists from a previous installation, notes are downloaded and uploaded.
 
 ### Synchronization
 
-Notes are synchronized immediately after you enable **Google Drive Sync**.
-Then on every My Notes **Open/Close/Refresh**, or with the **"Sync Now"** button.
+Notes are synchronized every time you hit the Sync button (bottom left corner).
 Synchronization works in both ways — to Google Drive, from Google Drive.
 
 ### Access
 
-My Notes can only access the files it created.
-It cannot see the other files in your Google Drive.
+My Notes has only access to the folder **My Notes**.
+It cannot see any other files in your Google Drive.
 
-<br>
+<br><br>
 
 ## Folder structure
 
@@ -146,7 +155,7 @@ LICENSE           # MIT
 manifest.json     # Main extension file
 
 
-background.html   # Entrypoint for background script
+background.html   # Entrypoint for background page
 background.js
 
 notes.html        # Entrypoint for notes
@@ -161,9 +170,11 @@ options.js
 README.md
 ```
 
-<br>
+<br><br>
 
 ## Permissions
+
+My Notes has the permissions listed in `manifest.json`.
 
 **Required:**
 
@@ -176,3 +187,9 @@ README.md
 - `"identity"` — used by **Enable Google Drive Sync** (see **Options**)
 
 `"tabs"` is a more powerful permission — the displayed warning may contain an unrelated message — `It can: Read your Browsing history`.
+
+<br><br>
+
+---
+
+<p align="center"><code>Created with ❤ in 2019.</code></p>

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "My Notes",
-  "description": "Simple Note-taking app. Auto-saved. Auto-synced.",
-  "version": "3.4",
+  "description": "Simple and fast note-taking.",
+  "version": "3.4.1",
   "homepage_url": "https://github.com/penge/my-notes",
   "icons": { "128": "images/icon128.png" },
   "options_page": "options.html",

--- a/notes.css
+++ b/notes.css
@@ -92,6 +92,10 @@ svg {
   border-radius: 3px;
 }
 
+.bar > .button.disabled {
+  opacity: .4;
+}
+
 .bar > .button > svg {
   height: .8em;
   pointer-events: none;

--- a/notes.css
+++ b/notes.css
@@ -86,12 +86,14 @@ svg {
 
 .bar > .button {
   font-weight: bold;
-  padding: .2em;
-  margin: .2em;
+  padding: .5em;
+  margin: .5em;
+  margin-right: 0;
+  border-radius: 3px;
 }
 
 .bar > .button > svg {
-  height: .7em;
+  height: .8em;
   pointer-events: none;
 }
 
@@ -111,19 +113,23 @@ body.with-sidebar { left: 25%; }
 body:not(.with-sidebar) { left: 0 !important; }
 
 #sidebar-notes {
-  margin-right: 1px;
+  margin-right: 1px; /* Drag */
+  padding: .5em;
   overflow-y: auto;
   flex-grow: 1;
   background: var(--sidebar-notes-background-color);
 }
 
-#sidebar .note {
+#sidebar-notes .note {
   cursor: pointer;
   font-weight: bold;
-  padding: .3em .5em;
+  padding: .5em 1em;
+  margin-top: 3px;
   color: var(--sidebar-notes-text-color);
+  border-radius: 3px;
 }
 
+#sidebar-notes .note:hover,
 #sidebar-notes .note.active {
   background: var(--sidebar-active-note-background-color);
   color: var(--sidebar-active-note-text-color);
@@ -335,7 +341,7 @@ body.with-modal #toolbar {
   outline: none;
   border: none;
   border-radius: 3px;
-  padding: .4em;
+  padding: .5em;
   font-family: inherit;
   font-size: .8em;
 }

--- a/notes.html
+++ b/notes.html
@@ -34,7 +34,7 @@
             s74.667,33.387,74.667,74.667S254.56,288,213.28,288z"/>
         </svg>
       </div>
-      <div id="sync-now" class="button" title="Click to sync to/from Google Drive now. Sync also happens automatically when My Notes is open or closed.">
+      <div id="sync-now" class="button disabled" title="Click to sync the notes to and from Google Drive now.">
         <svg viewBox="0 0 341.333 341.333">
             <path d="M341.227,149.333V0l-50.133,50.133C260.267,19.2,217.707,0,170.56,0C76.267,0,0.107,76.373,0.107,170.667
               s76.16,170.667,170.453,170.667c79.467,0,146.027-54.4,164.907-128h-44.373c-17.6,49.707-64.747,85.333-120.533,85.333

--- a/notes/hotkeys.js
+++ b/notes/hotkeys.js
@@ -29,9 +29,14 @@ const keydown = (state) => document.addEventListener("keydown", (event) => {
   }
 
   if (event.key === "Enter" || event.keyCode === 13) {
-    // Confirm #modal
+    // Look for #confirm in #modal
     const confirm = document.getElementById("confirm");
-    confirm && confirm.click();
+    if (confirm) {
+      // if modal is open and thefore can be confirmed and closed with Enter,
+      // prevent default behaviour of Enter
+      event.preventDefault();
+      confirm.click();
+    }
   }
 
   if ((event.metaKey || event.ctrlKey) && (event.key === "S" || event.key === "s")) {
@@ -59,21 +64,25 @@ const keydown = (state) => document.addEventListener("keydown", (event) => {
   }
 
   if ((event.metaKey || event.ctrlKey) && event.key === "[") {
+    event.preventDefault();
     state.previousNote();
     return;
   }
 
   if ((event.metaKey || event.ctrlKey) && event.key === "]") {
+    event.preventDefault();
     state.nextNote();
     return;
   }
 
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === "F" || event.key === "f")) {
+    event.preventDefault();
     state.active && toggleFocus(); // toggle focus only when a note is open
     return;
   }
 
   if ((event.metaKey || event.ctrlKey) && event.shiftKey && (event.key === "O" || event.key === "o")) {
+    event.preventDefault();
     chrome.tabs.create({ url: "/options.html" });
     return;
   }

--- a/notes/typing.js
+++ b/notes/typing.js
@@ -1,7 +1,7 @@
 import edit from "./edit.js";
 
 const initialize = (content, tabId) => {
-  content.addEventListener("keyup", () => edit(content, tabId));
+  content.addEventListener("input", () => edit(content, tabId));
 };
 
 export default { initialize };

--- a/notes/view/set-sync.js
+++ b/notes/view/set-sync.js
@@ -4,14 +4,13 @@ import formatDate from "../../shared/date/format-date.js";
 const title = syncNow.title;
 
 export default function setSync(sync) {
-  if (typeof sync !== "object") {
-    syncNow.classList.add("hide");
+  if (typeof sync !== "object" || !sync.lastSync) {
+    syncNow.classList.add("disabled");
+    syncNow.title = "Google Drive Sync is disabled (see Options).";
     return;
   }
 
-  syncNow.classList.remove("hide");
-  if (sync.lastSync) {
-    const date = formatDate(sync.lastSync);
-    syncNow.title = title + "\n\n" + "Last sync: " + date;
-  }
+  const date = formatDate(sync.lastSync);
+  syncNow.title = title + "\n\n" + "Last sync: " + date;
+  syncNow.classList.remove("disabled");
 }

--- a/options.html
+++ b/options.html
@@ -131,7 +131,7 @@
       <div>
         <label for="newtab" class="bold">Open My Notes in every New Tab</label>
         <div class="comment">
-          My Notes will request a permission in order to enable this feature.
+          My Notes will request permission to enable this feature.
         </div>
       </div>
     </div>
@@ -140,19 +140,18 @@
       <div>
         <label for="sync" class="bold">Enable Google Drive Sync</label>
         <div class="comment">
-          Stores the notes to your Google Drive in the folder <b>My Notes</b> (created automatically, once),
-          and synchronizes the changes in both ways — to Google Drive, from Google Drive — on every My Notes <b>Open/Close</b>,
-          or with the <b>"Sync Now"</b> button located in the sidebar.<br><br>
+          Creates a folder <b>My Notes</b> (automatically, once) in your Google Drive, and uses it to store the notes.
+          Notes are synchronized to and from Google Drive once enabled, and then on every click on the <b>Sync now</b> button in the sidebar.<br><br>
 
-          This gives you:<br>
+          <b>Benefits:</b><br>
           <ul>
-            <li>backup (notes can be restored in future)</li>
-            <li>can modify the notes in both sources (Google Drive, My Notes, and vice versa)</li>
-            <li>can modify the notes from other computers (by installing My Notes and using the same Google Account)</li>
+            <li>having a backup of notes (notes can be restored in the future)</li>
+            <li>can edit the notes from other sources (Google Drive, My Notes, vice versa)</li>
+            <li>can sync the notes and edit them from other computers (by installing My Notes and using the same Google Account)</li>
           </ul>
 
           My Notes can only access the files it created. It cannot see the other files in your Google Drive.<br>
-          My Notes will request a permission in order to enable this feature.<br><br>
+          My Notes will request permission to enable this feature.<br><br>
 
           <b>Location: </b><a id="sync-folder-location" class="bold" href="" target="_blank"></a><br>
           <b>Last sync: </b><span id="sync-last-sync" class="bold"></span>

--- a/shared/storage/default-values.js
+++ b/shared/storage/default-values.js
@@ -19,9 +19,9 @@ export default {
     genericFamily: "sans-serif",
     fontFamily: "Helvetica, sans-serif",
   },
-  size: 300,
-  theme: "light", // "light" or "dark"
-  customTheme: "",
+  size: 190,
+  theme: "light", // "light", "dark", "custom"
+  customTheme: "", // css string
 
   // Notes
   notes: () => notes(),

--- a/themes/light.css
+++ b/themes/light.css
@@ -45,9 +45,9 @@
 
   /* Sidebar */
 
-  --sidebar-notes-background-color: white;
+  --sidebar-notes-background-color: #f5f5f5;
   --sidebar-notes-text-color: black;
-  --sidebar-active-note-background-color: #e1e1e1;
+  --sidebar-active-note-background-color: #bdbdbd;
   --sidebar-active-note-text-color: black;
 
 
@@ -67,7 +67,7 @@
   --toolbar-button-color: black;
   --toolbar-button-hover-background-color: #222;
   --toolbar-button-hover-color: white;
-  --toolbar-submenu-background-color: #f1f1f1;
+  --toolbar-submenu-background-color: #f5f5f5;
 
 
   /* Editor */

--- a/themes/shared.css
+++ b/themes/shared.css
@@ -1,6 +1,6 @@
 /* Scrollbar */
 
-::-webkit-scrollbar { width: 10px; }
+::-webkit-scrollbar { width: 8px; }
 ::-webkit-scrollbar-track { background: var(--scrollbar-track-background-color); }
 ::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb-background-color); }
 ::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover-background-color); }


### PR DESCRIPTION
This is a version **3.4.1**.

**Changes:**

- Using Spellcheck to correct the words, is now recognized and the note it saved (Closes https://github.com/penge/my-notes/issues/121)
- Notes in the Notes list have more space around them, and pointing the mouse over a note changes its color 
- **"Sync now"** button is now always visible in the Sidebar, to have an idea that it's there when Google Drive Sync is enabled, and if disabled, **"Sync now"** button would have a gray color (and also a changed tooltip) to convey that the feature is disabled
- Synchronization of the notes now happens only when the user clicks the **"Sync now"** button, to minimize the number of requests made
- Default font size is changed to 190 (before 300)
- **README** is updated, description as well