### PR TITLE
Support "Open My Notes in every New Tab" in Edge

### DIFF
--- a/background/init/open.js
+++ b/background/init/open.js
@@ -8,7 +8,12 @@ const iconClick = () => chrome.browserAction.onClicked.addListener(() => {
   chrome.tabs.create({ url: "/notes.html" });
 });
 
-// Open My Notes in every new tab if enabled in Options -> "Open My Notes in every new tab"
+// It can be:
+// - in Chrome as "chrome://newtab/"
+// - in Edge as "edge://newtab/"
+const NEW_TAB_PATH = "://newtab";
+
+// Open My Notes in every New Tab if enabled in Options / "Open My Notes in every New Tab"
 const newtab = () => chrome.tabs.onCreated.addListener(async (tab) => {
   const newtab = await getItem("newtab");
   if (!newtab) {
@@ -22,7 +27,7 @@ const newtab = () => chrome.tabs.onCreated.addListener(async (tab) => {
   }
 
   // pendingUrl is available since Chrome 79; url is a fallback
-  if (tab.pendingUrl === "chrome://newtab/" || tab.url === "chrome://newtab/") {
+  if (tab.pendingUrl.includes(NEW_TAB_PATH) || tab.url.includes(NEW_TAB_PATH)) {
     chrome.tabs.update(tab.id, { url: "/notes.html" });
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "My Notes",
   "description": "Simple and fast note-taking.",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "homepage_url": "https://github.com/penge/my-notes",
   "icons": { "128": "images/icon128.png" },
   "options_page": "options.html",


### PR DESCRIPTION
**"Open My Notes in every New Tab"** option is now working in Edge (Microsoft Edge Browser).

Closes https://github.com/penge/my-notes/issues/128