### PR TITLE
Add Drag n Drop functionality

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,7 @@ import {
   contextMenu,
   notifications,
   open,
+  drop,
 
   googleDrive,
 } from "./background/init/index";
@@ -23,6 +24,9 @@ notifications.attach();
 
 // Click My Notes icon, "Open My Notes in every New Tab" (see Options)
 open.attach();
+
+// Drop text onto a note in Sidebar
+drop.attach();
 
 // Google Drive Sync
 googleDrive.attach();

--- a/src/background/init/drop.ts
+++ b/src/background/init/drop.ts
@@ -1,0 +1,38 @@
+import { NotesObject, Message, MessageType } from "shared/storage/schema";
+
+const attach = (): void => {
+  chrome.runtime.onMessage.addListener((message: Message) => {
+    if (message.type !== MessageType.DROP) {
+      return;
+    }
+
+    const { targetNoteName, data } = message.payload as { targetNoteName: string, data: string };
+    if (!targetNoteName || !data) {
+      return;
+    }
+
+    chrome.storage.local.get("notes", local => {
+      if (!(targetNoteName in local.notes)) {
+        return;
+      }
+
+      const oldContent = (local.notes as NotesObject)[targetNoteName].content;
+
+      const newContent = `${oldContent}<br><br>${data}`;
+
+      chrome.storage.local.set({
+        notes: {
+          ...local.notes,
+          [targetNoteName]: {
+            ...local.notes[targetNoteName],
+            content: newContent,
+          },
+        }
+      });
+    });
+  });
+};
+
+export default {
+  attach,
+};

--- a/src/background/init/index.ts
+++ b/src/background/init/index.ts
@@ -4,6 +4,7 @@ import migrations from "./migrations/index";
 import contextMenu from "./context-menu";
 import notifications from "./notifications";
 import open from "./open";
+import drop from "./drop";
 
 import googleDrive from "./google-drive";
 
@@ -29,6 +30,7 @@ export {
   contextMenu,
   notifications,
   open,
+  drop,
 
   googleDrive,
 };

--- a/src/shared/storage/schema.ts
+++ b/src/shared/storage/schema.ts
@@ -95,6 +95,7 @@ export enum MessageType {
   SYNC_STOP,
   SYNC_DELETE_FILE,
   SAVE_TO_CLIPBOARD,
+  DROP,
 }
 
 export interface Message {

--- a/static/notes.css
+++ b/static/notes.css
@@ -154,6 +154,43 @@ body:not(.with-sidebar) { left: 0 !important; }
   color: var(--sidebar-active-note-text-color);
 }
 
+#sidebar-notes .note.drag-over {
+  background: var(--selection-background-color);
+  color: var(--selection-text-color);
+}
+
+@keyframes confirmation {
+  0% {
+    background: var(--selection-background-color);
+    color: var(--selection-text-color);
+  }
+  100% {
+    background: initial;
+    color: initial;
+  }
+}
+
+#sidebar-notes .note.drag-over > svg {
+  fill: var(--selection-text-color);
+}
+
+@keyframes confirmationsvg {
+  0% {
+    fill: var(--selection-text-color);
+  }
+  100% {
+    fill: initial;
+  }
+}
+
+#sidebar-notes .note.drag-confirmation > svg {
+  animation: confirmationsvg .3s cubic-bezier(1, 0, 0.5, 1) 2 alternate;
+}
+
+#sidebar-notes .note.drag-confirmation {
+  animation: confirmation .3s cubic-bezier(1, 0, 0.5, 1) 2 alternate;
+}
+
 #sidebar-buttons .button {
   cursor: pointer;
 }

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -7,6 +7,11 @@
   --scrollbar-thumb-hover-background-color: #555;
 
 
+  /* Selection */
+  --selection-background-color: #008eff;
+  --selection-text-color: white;
+
+
   /* Generic */
 
   --background-color: #121212;

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -7,6 +7,11 @@
   --scrollbar-thumb-hover-background-color: #888;
 
 
+  /* Selection */
+  --selection-background-color: #008eff;
+  --selection-text-color: white;
+
+
   /* Generic */
 
   --background-color: white;

--- a/static/themes/shared.css
+++ b/static/themes/shared.css
@@ -5,6 +5,13 @@
 ::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb-background-color); }
 ::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover-background-color); }
 
+/* Selection */
+
+::selection {
+  background: var(--selection-background-color);
+  color: var(--selection-text-color);
+}
+
 /* Generic */
 
 body {


### PR DESCRIPTION
It is now possible to drag and drop text between notes by dropping the text onto a note's name. You can as well drop the text from outside application, like from other Chrome tab.

After you drop the text onto a note's name, it will flash in blue color 2-times, as a confirmation. This color can be modified in custom theme if needed, see `light.css` and `dark.css` for reference, where you will see two new variables:

```
--selection-background-color: <color>
--selection-text-color: <color>
```

Closes https://github.com/penge/my-notes/issues/174.