### PR TITLE
Fix tooltip flicker after note was edited

### DIFF
--- a/src/notes/components/Toolbar.tsx
+++ b/src/notes/components/Toolbar.tsx
@@ -395,7 +395,7 @@ const Toolbar = ({ os, note }: ToolbarProps): h.JSX.Element => {
           </div>
         </Tooltip>
 
-        <Tooltip className="info-tooltip" tooltip={note ? <NoteInfo note={note} /> : ""}>
+        <Tooltip id="info-tooltip" className="info-tooltip" tooltip={note ? <NoteInfo note={note} /> : ""}>
           <div id="INFO" class="button last">
             <svg viewBox="0 0 111.577 111.577">
               <path d="M78.962,99.536l-1.559,6.373c-4.677,1.846-8.413,3.251-11.195,4.217c-2.785,0.969-6.021,1.451-9.708,1.451

--- a/src/notes/components/Tooltip.tsx
+++ b/src/notes/components/Tooltip.tsx
@@ -1,13 +1,15 @@
 import { h, render, cloneElement, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { useRef, useState, useEffect, useMemo } from "preact/hooks";
+import { useRef, useState, useEffect, useMemo, useCallback } from "preact/hooks";
 
 interface TooltipProps {
+  id?: string
   tooltip: string | h.JSX.Element
   children: h.JSX.Element
   className?: string
 }
 
 interface TooltipRenderProps {
+  id?: string
   tooltip: string | h.JSX.Element
   childrenRect: DOMRect
   className?: string
@@ -93,17 +95,19 @@ const TooltipRender = ({ tooltip, childrenRect, className }: TooltipRenderProps)
 
 let renderProps: TooltipRenderProps | undefined;
 
-const Tooltip = ({ tooltip, children, className }: TooltipProps): h.JSX.Element => {
-  const show = (props: TooltipRenderProps) => render(<TooltipRender {...props} />, getContainer());
-  const hide = () => render("", getContainer());
+const Tooltip = ({ id, tooltip, children, className }: TooltipProps): h.JSX.Element => {
+  const show = useCallback((props: TooltipRenderProps) => render(<TooltipRender {...props} />, getContainer()), []);
+  const hide = useCallback(() => render("", getContainer()), []);
 
   useEffect(() => {
-    if (renderProps) {
-      show({
-        ...renderProps,
-        tooltip,
-      });
+    if (!renderProps || (id && renderProps.id !== id)) {
+      return;
     }
+
+    show({
+      ...renderProps,
+      tooltip,
+    });
   }, [tooltip]);
 
   const clone = cloneElement(children, {
@@ -112,7 +116,7 @@ const Tooltip = ({ tooltip, children, className }: TooltipProps): h.JSX.Element 
         return;
       }
       const childrenRect = event.currentTarget.getBoundingClientRect();
-      renderProps = { tooltip, childrenRect, className };
+      renderProps = { id, tooltip, childrenRect, className };
       show(renderProps);
     },
     onMouseLeave: () => {


### PR DESCRIPTION
This is a fix for already visible tooltip (for example tooltip for "B") that started to flicker after the note was edited, also solves situation that caused Note info tooltip (Info icon) to replace other visible tooltip.