### PR TITLE
Fix table row and column deletion, remember cell position in table

### DIFF
--- a/src/notes/range.ts
+++ b/src/notes/range.ts
@@ -19,6 +19,10 @@ const restore = (): void => {
   }
 };
 
+const empty = (): void => {
+  document.getSelection()?.empty();
+};
+
 export const withRange = (fn: (range: Range) => void): void => {
   const range = save();
   if (!range) {
@@ -31,4 +35,5 @@ export const withRange = (fn: (range: Range) => void): void => {
 export default {
   save,
   restore,
+  empty,
 };

--- a/src/notes/toolbar/table.ts
+++ b/src/notes/toolbar/table.ts
@@ -1,4 +1,4 @@
-import { withRange } from "../range";
+import __range, { withRange } from "../range";
 
 type Callback = () => void
 
@@ -29,7 +29,7 @@ const insertTable = (cb: Callback): void => withRange((range: Range) => {
   }
 
   range.insertNode(table);
-  document.getSelection()?.empty();
+  __range.empty();
   cb();
 });
 
@@ -38,6 +38,7 @@ const insertRowRelative = (delta: number, cb: Callback) => withtr((tr: HTMLTable
   const index = tr.rowIndex + delta;
   const cellCount = table.rows[0].cells.length;
   insertRow(table, index, cellCount);
+  __range.restore();
   cb();
 });
 
@@ -50,6 +51,7 @@ const insertColumnRelative = (delta: number, cb: Callback) => withtd((td: HTMLTa
   for (let row = 0; row < table.rows.length; row += 1) {
     table.rows[row].insertCell(index);
   }
+  __range.restore();
   cb();
 });
 
@@ -65,6 +67,7 @@ const toggleHeadingRow = (cb: Callback): void => withtd((td: HTMLTableDataCellEl
     tr.cells[c].classList.toggle("heading", !containsHeading);
   }
 
+  __range.restore();
   cb();
 });
 
@@ -77,6 +80,7 @@ const toggleHeadingColumn = (cb: Callback): void => withtd((td: HTMLTableCellEle
     table.rows[row].cells[cellIndex].classList.toggle("heading", !containsHeading);
   }
 
+  __range.restore();
   cb();
 });
 
@@ -90,6 +94,7 @@ const deleteRow = (cb: Callback): void => withtr((tr: HTMLTableRowElement) => {
     table.remove();
   }
 
+  __range.empty();
   cb();
 });
 
@@ -105,6 +110,7 @@ const deleteColumn = (cb: Callback): void => withtd((td: HTMLTableDataCellElemen
     table.remove();
   }
 
+  __range.empty();
   cb();
 });
 


### PR DESCRIPTION
Tables are improved. When you now click on any of these Toolbar actions:

- `Insert row above`
- `Insert row below`
- `Insert column left`
- `Insert column right`
- `Toggle heading row`
- `Toggle heading column`

you will continue to see the cursor position in the table cell where it was. This allows you not only to see from which table cell you applied any of the above actions, but also help you to apply them again without a need to find the cell, and click into the cell again.

Besides this, deletion of rows and columns was fixed, it fixes https://github.com/penge/my-notes/issues/154.