### PR TITLE
Fix cursor jumping to the beginning of the note

### DIFF
--- a/src/background/init/saving.ts
+++ b/src/background/init/saving.ts
@@ -21,7 +21,10 @@ export const saveTextToLocalMyNotes = (textToSave: string, noteName: string): vo
       modifiedTime: time,
     };
 
-    chrome.storage.local.set({ notes });
+    chrome.storage.local.set({
+      notes,
+      setFromBackground: true,
+    });
   });
 };
 
@@ -58,7 +61,7 @@ export const saveTextOnDrop = (): void => chrome.runtime.onMessage.addListener((
     }
 
     const oldContent = notes[targetNoteName].content;
-    const newContent = `${oldContent}<br><br>${data}`;
+    const newContent = `${data}<br><br>${oldContent}`;
     const modifiedTime = new Date().toISOString();
 
     notes[targetNoteName] = {
@@ -67,6 +70,9 @@ export const saveTextOnDrop = (): void => chrome.runtime.onMessage.addListener((
       modifiedTime,
     };
 
-    chrome.storage.local.set({ notes });
+    chrome.storage.local.set({
+      notes,
+      setFromBackground: true,
+    });
   });
 });

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -228,13 +228,17 @@ const Notes = () => {
           const newActive = newNoteName || prev.active;
 
           // Re-activate note updated from background or from other tab
+          const setFromBackground = changes["setFromBackground"] && changes["setFromBackground"].newValue;
           if (
+            setFromBackground &&
             (newActive in oldNotes) &&
             (newActive in newNotes) &&
-            (newNotes[newActive].content !== oldNotes[newActive].content) &&
-            (localStorage.getItem("notesChangedBy") !== tabId)
+            (newNotes[newActive].content !== oldNotes[newActive].content)
           ) {
             setInitialContent(newNotes[newActive].content);
+            setTimeout(() => {
+              chrome.storage.local.set({ setFromBackground: false });
+            }, 1000); // wait so other tabs can update its content too
           }
 
           if (!(newActive in oldNotes)) {

--- a/src/notes/content/save.ts
+++ b/src/notes/content/save.ts
@@ -1,18 +1,10 @@
 import { NotesObject } from "shared/storage/schema";
 
-let notesChangedByTimeout: number;
-const setChangedBy = (tabId: string) => {
-  clearTimeout(notesChangedByTimeout);
-  localStorage.setItem("notesChangedBy", tabId);
-  notesChangedByTimeout = window.setTimeout(() => localStorage.removeItem("notesChangedBy"), 1000);
-};
-
 export const saveNote = (active: string, content: string, tabId: string, notes: NotesObject): void => {
   if (!active || !tabId || !notes) {
     return;
   }
 
-  setChangedBy(tabId);
   const notesCopy: NotesObject = {
     ...notes,
     [active]: {


### PR DESCRIPTION
Fixes https://github.com/penge/my-notes/issues/188 – fixes jumping cursor to the beginning of the note after the note was edited.

**Cause of the problem:**
Problem was caused by refreshing the note as it would be updated by the Context menu. Context menu can be used to save selected text into a note, therefore update the note as well – and in that case, if the updated note would be open, it should be reloaded to show the updated content. Although the note was updated by the user and not the Context menu here, it was reloaded, while it should not.

**Solution:**
The solution was in changing the mechanism that knows if the note was updated by the user, or by the Context menu. If the note was updated by the Context menu, the background script (service worker) now provides a flag `setFromBackground` that is either true or false.