### PR TITLE
Fix note auto-update in other tabs

### DIFF
--- a/src/background/init/saving.ts
+++ b/src/background/init/saving.ts
@@ -5,6 +5,8 @@ import {
   Message,
 } from "shared/storage/schema";
 
+const getSetBy = (): string => `worker-${new Date().getTime()}`;
+
 export const saveTextToLocalMyNotes = (textToSave: string, noteName: string): void => {
   chrome.storage.local.get(["notes"], local => {
     const notes = local.notes as NotesObject;
@@ -23,7 +25,7 @@ export const saveTextToLocalMyNotes = (textToSave: string, noteName: string): vo
 
     chrome.storage.local.set({
       notes,
-      setFromBackground: true,
+      setBy: getSetBy(),
     });
   });
 };
@@ -72,7 +74,7 @@ export const saveTextOnDrop = (): void => chrome.runtime.onMessage.addListener((
 
     chrome.storage.local.set({
       notes,
-      setFromBackground: true,
+      setBy: getSetBy(),
     });
   });
 });

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -232,17 +232,14 @@ const Notes = () => {
           const newActive = newNoteName || prev.active;
 
           // Re-activate note updated from background or from other tab
-          const setFromBackground = changes["setFromBackground"] && changes["setFromBackground"].newValue;
+          const setBy: string = changes["setBy"] && changes["setBy"].newValue;
           if (
-            setFromBackground &&
+            (setBy && !setBy.startsWith(`${tabId}-`)) &&
             (newActive in oldNotes) &&
             (newActive in newNotes) &&
             (newNotes[newActive].content !== oldNotes[newActive].content)
           ) {
             setInitialContent(newNotes[newActive].content);
-            setTimeout(() => {
-              chrome.storage.local.set({ setFromBackground: false });
-            }, 1000); // wait so other tabs can update its content too
           }
 
           if (!(newActive in oldNotes)) {

--- a/src/notes/content/save.ts
+++ b/src/notes/content/save.ts
@@ -14,5 +14,8 @@ export const saveNote = (active: string, content: string, tabId: string, notes: 
     },
   };
 
-  chrome.storage.local.set({ notes: notesCopy });
+  chrome.storage.local.set({
+    notes: notesCopy,
+    setBy: `${tabId}-${new Date().getTime()}`,
+  });
 };


### PR DESCRIPTION
This is a further improvement to https://github.com/penge/my-notes/pull/225 – this one fixed jumping cursor to the beginning of the note after edit, but I found that **_auto-update_** of the same note open in **other tabs** stopped working.

Now this is fixed. The final solution is a combination of the solution prior to https://github.com/penge/my-notes/pull/225, and https://github.com/penge/my-notes/pull/225 itself. So we get best of both while fixing both problems.