### PR TITLE
Implement image drag-n-drop and image upload

### DIFF
--- a/src/background/google-drive/__tests__/bodies.test.ts
+++ b/src/background/google-drive/__tests__/bodies.test.ts
@@ -2,6 +2,7 @@ import {
   createFolderBody,
   createFileBody,
   updateFileBody,
+  uploadFileBody,
 } from "../bodies";
 
 
@@ -10,7 +11,21 @@ it("has valid create folder body", () => expect(createFolderBody("My Notes")).to
 Content-Type: application/json; charset=UTF-8
 
 {
+  "parents": [],
   "name": "My Notes",
+  "mimeType": "application/vnd.google-apps.folder"
+}
+
+--my-notes--`));
+
+
+it("has valid create folder body with parent", () => expect(createFolderBody("assets", "PARENT_ID")).toEqual(`
+--my-notes
+Content-Type: application/json; charset=UTF-8
+
+{
+  "parents": ["PARENT_ID"],
+  "name": "assets",
   "mimeType": "application/vnd.google-apps.folder"
 }
 
@@ -58,5 +73,31 @@ Content-Type: application/json; charset=UTF-8
 Content-Type: text/html
 
 buy milk, buy coffee
+
+--my-notes--`));
+
+
+it("has valid upload file body", () => expect(uploadFileBody("12345", {
+  name: "image.jpeg",
+  type: "image/jpeg",
+  content: "IMAGE_CONTENT",
+  createdTime: "CT",
+  modifiedTime: "MT"
+})).toEqual(`
+--my-notes
+Content-Type: application/json; charset=UTF-8
+
+{
+  "parents": ["12345"],
+  "name": "image.jpeg",
+  "createdTime": "CT",
+  "modifiedTime": "MT"
+}
+
+--my-notes
+Content-Type: image/jpeg
+Content-Transfer-Encoding: base64
+
+IMAGE_CONTENT
 
 --my-notes--`));

--- a/src/background/google-drive/__tests__/queries.test.ts
+++ b/src/background/google-drive/__tests__/queries.test.ts
@@ -1,0 +1,19 @@
+import {
+  listFoldersQuery,
+  listFilesQuery,
+} from "../queries";
+
+test("listFoldersQuery() returns query string to find My Notes folder", () => {
+  const query = listFoldersQuery("My Notes");
+  expect(query).toBe("name='My Notes' and mimeType='application/vnd.google-apps.folder' and trashed=false");
+});
+
+test("listFoldersQuery() returns query string to find assets folder inside My Notes folder", () => {
+  const query = listFoldersQuery("assets", "12345");
+  expect(query).toBe("'12345' in parents and name='assets' and mimeType='application/vnd.google-apps.folder' and trashed=false");
+});
+
+test("listFilesQuery() returns query string to find notes inside My Notes folder", () => {
+  const query = listFilesQuery("12345");
+  expect(query).toBe("'12345' in parents and mimeType='text/html' and trashed=false");
+});

--- a/src/background/google-drive/api.ts
+++ b/src/background/google-drive/api.ts
@@ -11,20 +11,26 @@ import {
 import { listFoldersQuery, listFilesQuery } from "./queries";
 import files from "./files/index";
 
-export const createMyNotesFolder = async (): Promise<string> => {
-  const body = createFolderBody("My Notes");
+const createFolder = async (folderName: string, parent?: string): Promise<string> => {
+  const body = createFolderBody(folderName, parent);
   const json = await files.create(body) as { id: string };
   const folderId = json && json.id;
   return folderId;
 };
 
-export const getMyNotesFolderId = async (): Promise<string> => {
-  const query = listFoldersQuery("My Notes");
+const getFolder = async (folderName: string, parent?: string): Promise<string> => {
+  const query = listFoldersQuery(folderName, parent);
   const fields = "files(id)";
   const json = await files.list(query, fields) as { files: {id: string}[] };
   const folderId = json && json.files && json.files[0] && json.files[0].id;
   return folderId;
 };
+
+export const createMyNotesFolder = (): Promise<string> => createFolder("My Notes");
+export const getMyNotesFolderId = (): Promise<string> => getFolder("My Notes");
+
+export const createAssetsFolder = (parent: string): Promise<string> => createFolder("assets", parent);
+export const getAssetsFolderId = (parent: string): Promise<string> => getFolder("assets", parent);
 
 export const createFile = async (folderId: string, { name, content, createdTime, modifiedTime }: CreateFileBodyOptions): Promise<GoogleDriveFile> => {
   const body = createFileBody(folderId, { name, content, createdTime, modifiedTime });

--- a/src/background/google-drive/bodies.ts
+++ b/src/background/google-drive/bodies.ts
@@ -1,8 +1,9 @@
-export const createFolderBody = (folderName: string): string => `
+export const createFolderBody = (folderName: string, parent?: string): string => `
 --my-notes
 Content-Type: application/json; charset=UTF-8
 
 {
+  "parents": ${parent ? `["${parent}"]` : "[]"},
   "name": "${folderName}",
   "mimeType": "application/vnd.google-apps.folder"
 }
@@ -55,6 +56,31 @@ Content-Type: application/json; charset=UTF-8
 
 --my-notes
 Content-Type: text/html
+
+${content}
+
+--my-notes--`;
+
+export interface UploadFileBodyOptions extends CreateFileBodyOptions {
+  type: string
+}
+
+export const uploadFileBody = (
+  parent: string, { name, type, content, createdTime, modifiedTime }: UploadFileBodyOptions
+): string => `
+--my-notes
+Content-Type: application/json; charset=UTF-8
+
+{
+  "parents": ["${parent}"],
+  "name": "${name}",
+  "createdTime": "${createdTime}",
+  "modifiedTime": "${modifiedTime}"
+}
+
+--my-notes
+Content-Type: ${type}
+Content-Transfer-Encoding: base64
 
 ${content}
 

--- a/src/background/google-drive/preconditions/common-preconditions.ts
+++ b/src/background/google-drive/preconditions/common-preconditions.ts
@@ -1,0 +1,39 @@
+import { Sync } from "shared/storage/schema";
+import { havingPermission } from "shared/permissions/index";
+import { getItem } from "shared/storage/index";
+import { Log } from "shared/logger";
+
+import stop from "../sync/stop";
+
+export const runCommonPreconditions = async (PREFIX: string): Promise<Sync | undefined> => {
+  // Check if having the Internet connection
+  if (!navigator.onLine) {
+    Log(`${PREFIX} - PROBLEM - not connected to the Internet`);
+    return; // We are offline
+  }
+
+  // Check if having the permission
+  const allowed = await havingPermission("identity");
+  if (!allowed) {
+    Log(`${PREFIX} - PROBLEM - not having a permission`);
+    return;
+  }
+
+  const sync = await getItem<Sync>("sync");
+
+  // Check if sync exists
+  if (!sync) {
+    Log(`${PREFIX} - PROBLEM - sync not set`);
+    await stop(); // STOP synchronization, cannot continue without sync
+    return;
+  }
+
+  // Check if folderId is set
+  if (!sync.folderId) {
+    Log(`${PREFIX} - PROBLEM - folderId not set`);
+    await stop(); // STOP synchronization, cannot continue without folderId
+    return;
+  }
+
+  return sync;
+};

--- a/src/background/google-drive/preconditions/sync-preconditions.ts
+++ b/src/background/google-drive/preconditions/sync-preconditions.ts
@@ -1,0 +1,41 @@
+import { SyncLookup } from "shared/storage/schema";
+import { Log } from "shared/logger";
+import { runCommonPreconditions } from "./common-preconditions";
+
+import stop from "../sync/stop";
+import * as api from "../api";
+
+export const runSyncPreconditions = async (PREFIX: string): Promise<SyncLookup | undefined> => {
+  const sync = await runCommonPreconditions(PREFIX);
+  if (!sync) {
+    return;
+  }
+
+  // Check if "My Notes" folder exists
+  const folderId = await api.getMyNotesFolderId();
+  if (!folderId || folderId !== sync.folderId) {
+    await stop(); // STOP synchronization; "My Notes" folder was deleted, or folderId was modified
+    return;
+  }
+
+  // Check if folderLocation is set
+  if (sync.folderLocation !== `https://drive.google.com/drive/u/0/folders/${folderId}`) {
+    Log(`${PREFIX} - PROBLEM - folderLocation not correct`);
+    await stop(); // STOP synchronization; folderLocation was modified
+    return;
+  }
+
+  // Check if can retrieve the files list
+  const files = await api.listFiles(sync.folderId);
+  if (!Array.isArray(files)) {
+    Log(`${PREFIX} - PROBLEM - cannot retrieve files`);
+    await stop();
+    return;
+  }
+
+  // All Good
+  return {
+    ...sync,
+    files,
+  };
+};

--- a/src/background/google-drive/preconditions/upload-preconditions.ts
+++ b/src/background/google-drive/preconditions/upload-preconditions.ts
@@ -1,0 +1,39 @@
+import { runCommonPreconditions } from "./common-preconditions";
+import * as api from "../api";
+import { getToken } from "shared/permissions/identity";
+import { setItem } from "shared/storage";
+import { Sync } from "shared/storage/schema";
+
+interface UploadPreconditionsResult {
+  sync: Sync
+  token: string
+}
+
+export const runUploadPreconditions = async (): Promise<UploadPreconditionsResult | undefined> => {
+  const sync = await runCommonPreconditions("UPLOAD");
+  if (!sync) {
+    return;
+  }
+
+  // Get existing "assets" folder ID, or create "assets" folder if not found
+  const assetsFolderId = sync.assetsFolderId || await api.getAssetsFolderId(sync.folderId) || await api.createAssetsFolder(sync.folderId);
+  if (sync.assetsFolderId !== assetsFolderId) {
+    await setItem("sync", {
+      ...sync,
+      assetsFolderId,
+    });
+  }
+
+  const token = await getToken();
+  if (!token) {
+    return;
+  }
+
+  return {
+    sync: {
+      ...sync,
+      assetsFolderId,
+    },
+    token,
+  };
+};

--- a/src/background/google-drive/queries.ts
+++ b/src/background/google-drive/queries.ts
@@ -1,7 +1,10 @@
-// Use to find My Notes folder
-export const listFoldersQuery = (name: string): string =>
-  `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+// Use to:
+// - find "My Notes" folder, or
+// - find "assets" folder inside "My Notes" folder
+export const listFoldersQuery = (name: string, parent?: string): string =>
+  `${parent ? `'${parent}' in parents and ` : ""}name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
 
-// Use to get list of files in My Notes folder
+// Use to:
+// - get list of files in "My Notes" folder
 export const listFilesQuery = (folderId: string): string =>
   `'${folderId}' in parents and mimeType='text/html' and trashed=false`;

--- a/src/background/google-drive/sync/initiate.ts
+++ b/src/background/google-drive/sync/initiate.ts
@@ -18,9 +18,13 @@ export default async (): Promise<Sync | undefined> => {
   }
   const folderLocation = `https://drive.google.com/drive/u/0/folders/${folderId}`;
 
+  // Get assets folder ID
+  const assetsFolderId = await api.getAssetsFolderId(folderId) || await api.createAssetsFolder(folderId);
+
   const sync: Sync = {
     folderId,
     folderLocation,
+    assetsFolderId,
   };
 
   await setItem<Sync>("sync", sync);

--- a/src/background/google-drive/sync/sync.ts
+++ b/src/background/google-drive/sync/sync.ts
@@ -1,14 +1,14 @@
-import { NotesObject, Sync, SyncLookup, MessageType } from "shared/storage/schema";
-
-import { havingPermission } from "shared/permissions/index";
+import { NotesObject, MessageType } from "shared/storage/schema";
 import { getItem, setItem } from "shared/storage/index";
-import * as api from "../api";
+import { sendMessage } from "messages/index";
 
-import stop from "./stop";
+import { runSyncPreconditions } from "../preconditions/sync-preconditions";
+
 import pull from "./pull";
 import push from "./push";
 
-import { sendMessage } from "messages/index";
+import * as api from "../api";
+import { Log } from "shared/logger";
 
 // File actions
 const getFile = api.getFile;
@@ -16,67 +16,8 @@ const createFile = api.createFile;
 const updateFile = api.updateFile;
 const deleteFile = api.deleteFile;
 
-const runPreconditions = async (PREFIX: string): Promise<SyncLookup | undefined> => {
-  // Check if having the Internet connection
-  if (!navigator.onLine) {
-    console.log(`${PREFIX} - PROBLEM - not connected to the Internet`);
-    return; // We are offline
-  }
-
-  // Check if having the permission
-  const allowed = await havingPermission("identity");
-  if (!allowed) {
-    console.log(`${PREFIX} - PROBLEM - not having a permission`);
-    return;
-  }
-
-  const sync = await getItem<Sync>("sync");
-
-  // Check if sync exists
-  if (!sync) {
-    console.log(`${PREFIX} - PROBLEM - sync not set`);
-    await stop(); // STOP synchronization, cannot continue without sync
-    return;
-  }
-
-  // Check if folderId is set
-  if (!sync.folderId) {
-    console.log(`${PREFIX} - PROBLEM - folderId not set`);
-    await stop(); // STOP synchronization, cannot continue without folderId
-    return;
-  }
-
-  // Check if "My Notes" folder exists
-  const folderId = await api.getMyNotesFolderId();
-  if (!folderId || folderId !== sync.folderId) {
-    await stop(); // STOP synchronization; "My Notes" folder was deleted, or folderId was modified
-    return;
-  }
-
-  // Check if folderLocation is set
-  if (sync.folderLocation !== `https://drive.google.com/drive/u/0/folders/${folderId}`) {
-    console.log(`${PREFIX} - PROBLEM - folderLocation not correct`);
-    await stop(); // STOP synchronization; folderLocation was modified
-    return;
-  }
-
-  // Check if can retrieve the files list
-  const files = await api.listFiles(folderId);
-  if (!Array.isArray(files)) {
-    console.log(`${PREFIX} - PROBLEM - cannot retrieve files`);
-    await stop();
-    return;
-  }
-
-  // All Good
-  return {
-    ...sync,
-    files,
-  };
-};
-
 const sync = async (): Promise<boolean> => {
-  const fulfilled = await runPreconditions("SYNC");
+  const fulfilled = await runSyncPreconditions("SYNC");
   if (!fulfilled) {
     sendMessage(MessageType.SYNC_FAIL);
     return false;
@@ -88,7 +29,7 @@ const sync = async (): Promise<boolean> => {
     return false;
   }
 
-  console.log("SYNC - START");
+  Log("SYNC - START");
   sendMessage(MessageType.SYNC_START);
 
   const notesAfterPull = await pull(notes, files, { getFile });
@@ -96,14 +37,14 @@ const sync = async (): Promise<boolean> => {
   await setItem("notes", notesAfterPush);
   await setItem("sync", { folderId, folderLocation, files, lastSync: new Date().toISOString() });
 
-  console.log("SYNC - DONE");
+  Log("SYNC - DONE");
   sendMessage(MessageType.SYNC_DONE);
 
   return true;
 };
 
 const syncDeleteFile = async (fileId: string): Promise<boolean> => {
-  const fulfilled = await runPreconditions("SYNC_DELETE_FILE");
+  const fulfilled = await runSyncPreconditions("SYNC_DELETE_FILE");
   if (!fulfilled) {
     return false;
   }
@@ -111,11 +52,11 @@ const syncDeleteFile = async (fileId: string): Promise<boolean> => {
   const { files } = fulfilled;
   const fileExists = fileId && files.find(file => file.id === fileId) !== undefined;
   if (!fileExists) {
-    console.log(`SYNC_DELETE_FILE - PROBLEM - cannot delete file with ID ${fileId}`);
+    Log(`SYNC_DELETE_FILE - PROBLEM - cannot delete file with ID ${fileId}`);
     return false;
   }
 
-  console.log(`%cSYNC_DELETE_FILE - DELETING FILE - ${fileId}`, "color: red");
+  Log(`%cSYNC_DELETE_FILE - DELETING FILE - ${fileId}`, "red");
   return await deleteFile(fileId);
 };
 

--- a/src/notes/components/image/__tests__/drop-image.test.ts
+++ b/src/notes/components/image/__tests__/drop-image.test.ts
@@ -1,0 +1,9 @@
+import {
+  getBase64FromDataURL,
+} from "../drop-image";
+
+test("getBase64FromDataURL() returns base64 from data URL", () => {
+  const dataURL = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASA";
+  const base64 = getBase64FromDataURL(dataURL);
+  expect(base64).toBe("/9j/4AAQSkZJRgABAQEASA");
+});

--- a/src/notes/components/image/__tests__/image-skeleton.test.ts
+++ b/src/notes/components/image/__tests__/image-skeleton.test.ts
@@ -1,0 +1,76 @@
+import { JSDOM } from "jsdom";
+import {
+  createImageSkeleton,
+  updateImageUploadProgress,
+  createImageElement,
+  replaceImageSkeletonWithImage,
+} from "../image-skeleton";
+
+const skeletonFactory = () => createImageSkeleton({
+  width: 300,
+  height: 200,
+  result: "IMAGE_CONTENT",
+});
+
+const prepareDom = (skeleton: HTMLDivElement): JSDOM => {
+  const dom = new JSDOM();
+  dom.window.document.body.insertAdjacentHTML("afterbegin", skeleton.outerHTML);
+  return dom;
+};
+
+test("createImageSkeleton() returns HTML skeleton", () => {
+  const dom = prepareDom(skeletonFactory());
+
+  /* eslint-disable quotes */
+  expect(dom.window.document.body.innerHTML).toBe(
+    '<div id="my-notes-image-skeleton" style="width: 300px; height: 200px;">' +
+      '<img id="my-notes-image-to-upload" src="IMAGE_CONTENT">' +
+      '<div id="my-notes-image-to-upload-overlay-caption">Uploading...</div>' +
+      '<div id="my-notes-image-to-upload-overlay" style="width: 100%;"></div>' +
+    '</div>'
+  );
+});
+
+test("updateImageUploadProgress() updates image upload progress for the skeleton", () => {
+  const dom = prepareDom(skeletonFactory());
+
+  const getElement = () => dom.window.document.getElementById("my-notes-image-to-upload-overlay") as HTMLDivElement;
+
+  expect(getElement().style.width).toBe("100%"); // initial width should be 100%
+
+  updateImageUploadProgress(dom.window.document, 30);
+  expect(getElement().style.width).toBe("70%");
+
+  updateImageUploadProgress(dom.window.document, 50);
+  expect(getElement().style.width).toBe("50%");
+
+  updateImageUploadProgress(dom.window.document, 80);
+  expect(getElement().style.width).toBe("20%");
+
+  updateImageUploadProgress(dom.window.document, 100);
+  expect(getElement().style.width).toBe("0%");
+});
+
+test("createImageElement() returns Image element", () => {
+  const spy = jest.spyOn(Date.prototype, "getTime").mockReturnValue(1610098861000); // "2021-01-08T09:41:01Z"
+
+  const image = createImageElement("http://localhost/image.jpeg", 600, 400);
+  expect(image.id).toBe("my-notes-image-1610098861000");
+  expect(image.className).toBe("my-notes-image");
+  expect(image.src).toBe("http://localhost/image.jpeg");
+  expect(image.width).toBe(600);
+  expect(image.height).toBe(400);
+
+  spy.mockRestore();
+});
+
+test("replaceImageSkeletonWithImage() replaces skeleton with the image", () => {
+  const dom = prepareDom(skeletonFactory());
+  expect(dom.window.document.getElementById("my-notes-image-skeleton")).toBeTruthy();
+
+  const image = dom.window.document.createElement("img");
+  replaceImageSkeletonWithImage(dom.window.document, image);
+
+  expect(dom.window.document.getElementById("my-notes-image-skeleton")).toBeFalsy();
+  expect(dom.window.document.body.innerHTML).toBe("<img>");
+});

--- a/src/notes/components/image/drop-image.ts
+++ b/src/notes/components/image/drop-image.ts
@@ -1,0 +1,64 @@
+import { h } from "preact";
+import { isImageFile, readImageFile } from "./read-image";
+import {
+  createImageSkeleton,
+  updateImageUploadProgress,
+  createImageElement,
+  replaceImageSkeletonWithImage,
+  removeSkeleton,
+} from "./image-skeleton";
+import { uploadImage } from "./upload-image";
+import { Sync } from "shared/storage/schema";
+
+interface DropImageProps {
+  event: h.JSX.TargetedDragEvent<HTMLDivElement>
+  sync: Sync
+  token: string
+  file: File
+  onComplete: () => void
+}
+
+export const getBase64FromDataURL = (dataUrl: string): string => dataUrl.replace(/^data:(.*,)?/, "");
+
+export const dropImage = async ({ event, sync, token, file, onComplete }: DropImageProps): Promise<void> => {
+  if (!isImageFile(file)) {
+    return;
+  }
+
+  const imageProps = await readImageFile(file);
+  if (!imageProps) {
+    return;
+  }
+
+  // 1. Insert image skeleton
+  const skeleton = createImageSkeleton(imageProps);
+  const range = document.caretRangeFromPoint(event.clientX, event.clientY);
+  range.insertNode(skeleton);
+
+  // 2. Upload the image
+  uploadImage({
+    sync,
+    token,
+    image: {
+      name: file.name,
+      type: file.type,
+      data: getBase64FromDataURL(imageProps.result),
+      width: imageProps.width,
+      height: imageProps.height,
+    },
+    onProgress: (progress: number) => updateImageUploadProgress(document, progress),
+    onUploaded: (src: string, width: number, height: number) => {
+      const image = createImageElement(src, width, height);
+      image.onload = () => {
+        // 3. Replace the skeleton with the uploaded image
+        document.body.classList.remove("locked");
+        replaceImageSkeletonWithImage(document, image);
+        onComplete();
+      };
+    },
+    onError: () => {
+      removeSkeleton();
+      document.body.classList.remove("locked");
+    },
+  });
+};

--- a/src/notes/components/image/image-skeleton.ts
+++ b/src/notes/components/image/image-skeleton.ts
@@ -1,0 +1,93 @@
+import { ReadImageProps } from "./read-image";
+
+const SKELETON_ID = "my-notes-image-skeleton";
+const IMAGE_TO_UPLOAD_ID = "my-notes-image-to-upload";
+const IMAGE_TO_UPLOAD_OVERLAY_CAPTION_ID = "my-notes-image-to-upload-overlay-caption";
+const IMAGE_TO_UPLOAD_OVERLAY_ID = "my-notes-image-to-upload-overlay";
+
+/**
+ * Returns div#SKELETON_ID with three children:
+ * - img#IMAGE_TO_UPLOAD_ID, that shows the image preview,
+ * - div#IMAGE_TO_UPLOAD_OVERLAY_CAPTION_ID, that shows "Uploading...", and,
+ * - div#IMAGE_TO_UPLOAD_OVERLAY_ID, that updates the image upload progress.
+ */
+export const createImageSkeleton = (props: ReadImageProps): HTMLDivElement => {
+  const skeleton = document.createElement("div");
+  skeleton.id = SKELETON_ID;
+  skeleton.contentEditable = "false";
+  skeleton.style.width = `${props.width}px`;
+  skeleton.style.height = `${props.height}px`;
+
+  const img = document.createElement("img");
+  img.id = IMAGE_TO_UPLOAD_ID;
+  img.src = props.result as string;
+
+  const overlayCaption = document.createElement("div");
+  overlayCaption.id = IMAGE_TO_UPLOAD_OVERLAY_CAPTION_ID;
+  overlayCaption.innerHTML = "Uploading...";
+
+  const overlay = document.createElement("div");
+  overlay.id = IMAGE_TO_UPLOAD_OVERLAY_ID;
+  overlay.style.width = "100%";
+
+  skeleton.appendChild(img);
+  skeleton.appendChild(overlayCaption);
+  skeleton.appendChild(overlay);
+
+  return skeleton;
+};
+
+/**
+ * Updates width of div#IMAGE_TO_UPLOAD_OVERLAY_ID to match the upload progress.
+ *
+ * As the upload progresses, we change div#IMAGE_TO_UPLOAD_OVERLAY_ID width
+ * from 100% to 0% to reveal the image behind from the left to the right.
+ */
+export const updateImageUploadProgress = (document: Document, progress: number): void => {
+  const overlay = document.getElementById(IMAGE_TO_UPLOAD_OVERLAY_ID);
+  if (!overlay) {
+    return;
+  }
+
+  overlay.style.width = `${Math.abs(progress - 100)}%`;
+};
+
+export const createImageElement = (src: string, width: number, height: number): HTMLImageElement => {
+  const image = new Image();
+  image.id = `my-notes-image-${new Date().getTime()}`;
+  image.className = "my-notes-image";
+  image.src = src;
+  image.width = width;
+  image.height = height;
+  return image;
+};
+
+export const removeSkeleton = (): void => {
+  const skeleton = document.getElementById(SKELETON_ID);
+  if (skeleton) {
+    skeleton.remove();
+  }
+};
+
+export const replaceImageSkeletonWithImage = (document: Document, image: HTMLImageElement): void => {
+  const skeleton = document.getElementById(SKELETON_ID);
+
+  if (!skeleton) {
+    return;
+  }
+
+  skeleton.replaceWith(image);
+
+  const replacedImage = document.getElementById(image.id);
+  if (!replacedImage) {
+    return;
+  }
+
+  const range = document.createRange();
+  range.setStartAfter(replacedImage);
+  range.setEndAfter(replacedImage);
+
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+};

--- a/src/notes/components/image/read-image.ts
+++ b/src/notes/components/image/read-image.ts
@@ -1,0 +1,31 @@
+export interface ReadImageProps {
+  width: number
+  height: number
+  result: string
+}
+
+export const isImageFile = (file: File): boolean => {
+  return file.type.match("image/*") !== null;
+};
+
+export const readImageFile = (file: File): Promise<ReadImageProps | undefined> => new Promise((resolve) => {
+  if (!isImageFile(file)) {
+    resolve(undefined);
+    return;
+  }
+
+  const reader = new FileReader();
+
+  reader.onloadend = () => {
+    const image = new Image();
+    image.onload = () => resolve({
+      width: image.width,
+      height: image.height,
+      result: reader.result as string,
+    });
+
+    image.src = reader.result as string;
+  };
+
+  reader.readAsDataURL(file);
+});

--- a/src/notes/components/image/upload-image.ts
+++ b/src/notes/components/image/upload-image.ts
@@ -1,0 +1,97 @@
+import { uploadFileBody } from "background/google-drive/bodies";
+import * as api from "background/google-drive/api";
+import { Sync } from "shared/storage/schema";
+import { setItem } from "shared/storage";
+import { Log } from "shared/logger";
+import stop from "background/google-drive/sync/stop";
+
+interface Image {
+  name: string
+  type: string
+  data: string
+  width: number
+  height: number
+}
+
+interface UploadImageProps {
+  sync: Sync
+  token: string
+  image: Image
+  onProgress: (progress: number) => void
+  onUploaded: (src: string, width: number, height: number) => void
+  onError: () => void
+}
+
+const uploadImageCore = async (run: number, { sync, token, image, onProgress, onUploaded, onError }: UploadImageProps): Promise<void> => {
+  if (run > 2) {
+    return;
+  }
+
+  const xhr = new XMLHttpRequest();
+  xhr.open("POST", "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart");
+  xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+  xhr.setRequestHeader("Accept", "application/json");
+  xhr.setRequestHeader("Content-Type", "multipart/related; boundary=my-notes");
+
+  xhr.upload.onprogress = (event) => {
+    if (event.lengthComputable) {
+      const percentComplete = event.loaded / event.total * 100;
+      onProgress(percentComplete);
+    }
+  };
+
+  xhr.onload = async () => {
+    const json = JSON.parse(xhr.response);
+    if (!json) {
+      return;
+    }
+
+    const errorMessage: string | undefined = json.error && json.error.message;
+    if (errorMessage === `File not found: ${sync.assetsFolderId}.`) {
+      Log("IMAGE UPLOAD - PROBLEM - \"assets\" folder does not exist (will try to create it)");
+
+      const newAssetsFolderId = await api.getAssetsFolderId(sync.folderId) || await api.createAssetsFolder(sync.folderId);
+      if (!newAssetsFolderId) {
+        Log("IMAGE UPLOAD - PROBLEM - \"My Notes\" folder does not exist (will stop sync)");
+        await stop();
+        onError();
+        return;
+      }
+
+      const updatedSync = {
+        ...sync,
+        assetsFolderId: newAssetsFolderId,
+      };
+
+      await setItem("sync", {
+        ...sync,
+        assetsFolderId: newAssetsFolderId,
+      });
+
+      uploadImageCore(run + 1, { sync: updatedSync, token, image, onProgress, onUploaded, onError });
+      return;
+    }
+
+    const imageId: string = json.id;
+    if (imageId) {
+      const src = `https://drive.google.com/uc?id=${imageId}`;
+      onUploaded(src, image.width, image.height);
+    }
+  };
+
+  const time = new Date().toISOString();
+
+  const body = uploadFileBody(sync.assetsFolderId, {
+    name: image.name,
+    type: image.type,
+    content: image.data,
+    createdTime: time,
+    modifiedTime: time,
+  });
+
+  xhr.send(body);
+};
+
+export const uploadImage = (props: UploadImageProps): void => {
+  uploadImageCore(1, props);
+};

--- a/src/notes/components/modals/InsertImageModal.tsx
+++ b/src/notes/components/modals/InsertImageModal.tsx
@@ -6,6 +6,19 @@ export interface InsertImageModalProps {
   onConfirm: (src: string) => void
 }
 
+// Transforms Google Drive image url
+// - from: https://drive.google.com/file/d/1y0...v9S/view
+// - to: https://drive.google.com/uc?id=1y0...v9S
+// otherwise keeps the url unchanged.
+export const transformImageUrl = (src: string): string => {
+  const googleLinkMatch = src.match(new RegExp("https://drive.google.com/file/d/(.*)/view"));
+  if (googleLinkMatch) {
+    return `https://drive.google.com/uc?id=${googleLinkMatch[1]}`;
+  }
+
+  return src;
+};
+
 const InsertImageModal = ({ onCancel, onConfirm }: InsertImageModalProps): h.JSX.Element => (
   <Modal
     className="with-border"
@@ -15,7 +28,12 @@ const InsertImageModal = ({ onCancel, onConfirm }: InsertImageModalProps): h.JSX
     confirmValue="Insert"
     validate={(src) => src.length > 0}
     onCancel={onCancel}
-    onConfirm={onConfirm}
+    onConfirm={(src) => onConfirm(transformImageUrl(src))}
+    description={(
+      <div className="modal-description">
+        You can <strong>Drag & Drop</strong> an image to note to upload it to Google Drive when Google Drive Sync is enabled.
+      </div>
+    )}
   />
 );
 

--- a/src/notes/components/modals/__tests__/InsertImageModal.test.ts
+++ b/src/notes/components/modals/__tests__/InsertImageModal.test.ts
@@ -1,0 +1,11 @@
+import {
+  transformImageUrl,
+} from "../InsertImageModal";
+
+test("transformImageUrl() transforms Google Drive image url", () => {
+  expect(transformImageUrl("https://drive.google.com/file/d/1y0v9S/view"))
+    .toBe("https://drive.google.com/uc?id=1y0v9S");
+
+  expect(transformImageUrl("https://anything.com/any-image.png"))
+    .toBe("https://anything.com/any-image.png");
+});

--- a/src/shared/storage/schema.ts
+++ b/src/shared/storage/schema.ts
@@ -35,6 +35,7 @@ export interface Notification {
 export interface Sync {
   folderId: string
   folderLocation: string
+  assetsFolderId: string
   lastSync?: string
 }
 

--- a/static/notes.css
+++ b/static/notes.css
@@ -276,6 +276,47 @@ body.with-control #content a {
 .my-notes-text-color-white    { color: white; }
 .my-notes-text-color-silver   { color: silver; }
 
+#my-notes-image-skeleton {
+  position: relative;
+  display: inline-block;
+  user-select: none;
+  background: #f5f5f5;
+}
+
+#my-notes-image-to-upload-overlay-caption {
+  z-index: 10;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: .5em;
+  background: #1565c0;
+  color: white;
+}
+
+#my-notes-image-to-upload-overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  opacity: .6;
+  background: white;
+}
+
+body.locked #sidebar,
+body.locked #toolbar {
+  user-select: none;
+  pointer-events: none;
+}
+
+body.locked #content {
+  user-select: none;
+  -webkit-user-modify: read-only;
+}
+
+.my-notes-image {
+  background: #f9f9f9;
+}
+
 /* Context menu */
 
 #context-menu {


### PR DESCRIPTION
Implements image **Drag & Drop** that uploads image to _**Google Drive**_. Images are uploaded to **"assets"** folder (created automatically when needed) inside "My Notes" folder in _**Google Drive**_.

Prerequisites for Drag & Drop in order to work:

1. Dropped file is of an **image** type (it has valid MIME type for images).
2. Having internet connection.
3. Having permission to use Google Drive (approved `identity` permission).
4. `sync` is defined in Google Storage Local.
5. `sync` has `folderId` set (points to **"My Notes"** folder in Google Drive).
6. `sync` has `assetsFolderId` set (points to **"assets"** folder inside "My Notes" folder in Google Drive), or created automatically when needed.
7. Having access token (`identity` permission required).

<br>

### **Questions:**

Q: What if I delete **"assets"** folder from Google Drive, how does that affect step number 6?
A: First image upload will fail due to not existing folder **"assets"**. My Notes will automatically recreate folder **"assets"**, get its new `assetsFolderId`, and repeat the upload. This time successfully. **Note:** This scenario should never be the case but My Notes can handle it.

Q: Question related to the previous question. Why not always check first if **"assets"** folder exists?
A: Although that could work, it would be slow as the goal is to do all Prerequisites check without making any network requests. That way, Image skeleton can be inserted immediately and user experience is better. Optimistic resolution is expected.

Q: What if I delete both **"assets"** and **"My Notes"** folders from Google Drive? How does that affect image Drag & Drop?
A: In this case, recreation of **"assets"** folder will fail because of not existing **"My Notes"** folder, the resolution will be to stop Google Drive Sync. Image skeleton will be removed from the note as it couldn't be uploaded.

<br>

Closes https://github.com/penge/my-notes/issues/220.
Closes https://github.com/penge/my-notes/issues/149.