### PR TITLE
Improve text highlight to also work on links

### DIFF
--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -478,7 +478,6 @@ const Notes = () => {
       <__Toolbar
         os={os}
         note={notesProps.notes[notesProps.active]}
-        theme={theme}
       />
 
       {contextMenuProps && (

--- a/src/notes/components/Toolbar.tsx
+++ b/src/notes/components/Toolbar.tsx
@@ -53,7 +53,7 @@ interface ToolbarProps {
   theme?: Theme
 }
 
-const Toolbar = ({ os, note, theme }: ToolbarProps): h.JSX.Element => {
+const Toolbar = ({ os, note }: ToolbarProps): h.JSX.Element => {
   const getTitle = useCallback((key: string) => {
     const title = (os && titles[key] && titles[key][os]) || "";
     return title;
@@ -75,16 +75,6 @@ const Toolbar = ({ os, note, theme }: ToolbarProps): h.JSX.Element => {
 
   const [insertImageModalProps, setInsertImageModalProps] = useState<InsertImageModalProps | null>(null);
   const [insertLinkModalProps, setInsertLinkModalProps] = useState<InsertLinkModalProps | null>(null);
-
-  const ThemeColorFilter = useCallback((color: string): boolean => {
-    if (
-      (theme === "dark" && ["black", "white", "silver", "purple"].includes(color)) ||
-      (theme === "light" && ["white", "purple"].includes(color))
-    ) {
-      return false;
-    }
-    return true;
-  }, [theme]);
 
   return (
     <Fragment>
@@ -443,11 +433,14 @@ const Toolbar = ({ os, note, theme }: ToolbarProps): h.JSX.Element => {
                 C51.026,90.566,37.074,89.198,37.074,89.198z"/>
             </svg>
             <div class="menu bar" style={{ paddingLeft: ".3em" }}>
-              {HIGHLIGHT_COLORS.filter(ThemeColorFilter).map((color) => (
+              {HIGHLIGHT_COLORS.map((color) => (
                 <Tooltip tooltip={`Change selected text color to ${capitalize(color)}`}>
                   <div class={`plain button letter my-notes-text-color-${color}`} onClick={() => commands.highlight(`my-notes-text-color-${color}`, callback)}>A</div>
                 </Tooltip>
               ))}
+              <Tooltip tooltip="Change selected text color to default text color">
+                <div class="plain button letter my-notes-text-color-auto" onClick={() => commands.highlight("my-notes-text-color-auto", callback)}>Auto</div>
+              </Tooltip>
               <Tooltip tooltip="Highlight selected text">
                 <div class="last plain button auto letter my-notes-highlight" onClick={() => commands.highlight("my-notes-highlight", callback)}>Hi</div>
               </Tooltip>

--- a/static/notes.css
+++ b/static/notes.css
@@ -275,6 +275,7 @@ body.with-control #content a {
 .my-notes-text-color-black    { color: black; }
 .my-notes-text-color-white    { color: white; }
 .my-notes-text-color-silver   { color: silver; }
+.my-notes-text-color-auto     { color: var(--text-color); }
 
 #my-notes-image-skeleton {
   position: relative;


### PR DESCRIPTION
Changing link's text color would break the feature to open the link with `Ctrl + Click` before. Now, this is fixed, both text color or text highlight, can be applied.

Closes https://github.com/penge/my-notes/issues/243.

<br>

<ins>Other changes:</ins>

Removing `ThemeColorFilter` as it is better to remove **black** and white color options completely.
It could cause problems when **black** color is applied, but you then change theme to **Dark**,
or white color is applied, but you then change theme to Light.
In these cases, text would become _invisible_.

Adding **Auto** option under Text Color button, which will use default text color,
which can be **black**, white, or any else <ins>based on the theme</ins>.
This way, text color can be reset.

Adding important clause that surrounds to-be-highlighted `TEXT_NODE`
with `<span>` when parent is `#content`.