### PR TITLE
Remove the need for opacity 1 in themes

### DIFF
--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -11,7 +11,7 @@ import {
   Message,
   MessageType,
 } from "shared/storage/schema";
-import setThemeCore from "themes/set-theme";
+import { setTheme as setThemeCore } from "themes/set-theme";
 
 import __Notification from "notes/components/Notification";
 import __Sidebar from "notes/components/Sidebar";
@@ -319,7 +319,7 @@ const Notes = () => {
     // - light.css
     // - dark.css
     // - customTheme string
-    theme && setThemeCore({ name: theme, customTheme: customTheme });
+    theme && setThemeCore(document, { theme, customTheme: customTheme });
   }, [theme, customTheme]);
 
   // Focus

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -14,7 +14,7 @@ import {
   Theme,
   Sync,
 } from "shared/storage/schema";
-import setThemeCore from "themes/set-theme";
+import { setTheme as setThemeCore } from "themes/set-theme";
 
 const Options = () => {
   const [version] = useState<string>(chrome.runtime.getManifest().version);
@@ -85,7 +85,7 @@ const Options = () => {
     // - light.css
     // - dark.css
     // - customTheme string
-    theme && setThemeCore({ name: theme, customTheme: customTheme });
+    theme && setThemeCore(document, { theme, customTheme: customTheme });
   }, [theme, customTheme]);
 
   return (

--- a/src/themes/__tests__/set-theme.test.ts
+++ b/src/themes/__tests__/set-theme.test.ts
@@ -1,0 +1,83 @@
+import { JSDOM } from "jsdom";
+import { Theme } from "shared/storage/schema";
+import { setTheme } from "../set-theme";
+
+const __expectOnlyOneChildInHead = (dom: JSDOM) => {
+  // only 1 theme should be inserted, changing theme should remove the previous theme
+  expect(dom.window.document.head.children.length).toBe(1);
+};
+
+const __expectInsertedLinkElement = (dom: JSDOM, expectedTheme: Theme) => {
+  __expectOnlyOneChildInHead(dom);
+
+  const linkElement = dom.window.document.head.firstChild as HTMLLinkElement;
+  expect(linkElement.id).toBe("theme");
+  expect(linkElement.rel).toBe("stylesheet");
+  expect(linkElement.href).toBe(`themes/${expectedTheme}.css`);
+};
+
+const __expectInsertedStyleElement = (dom: JSDOM, expectedCustomTheme: string) => {
+  __expectOnlyOneChildInHead(dom);
+
+  const styleElement = dom.window.document.head.firstChild as HTMLStyleElement;
+  expect(styleElement.id).toBe("theme");
+  expect(styleElement.innerHTML).toBe(expectedCustomTheme);
+};
+
+const __expectUpdatedBody = (dom: JSDOM, expectedId: Theme) => {
+  expect(dom.window.document.body.id).toBe(expectedId);
+  expect(dom.window.document.body.style.opacity).toBe("1");
+};
+
+test("light theme is inserted", () => {
+  const dom = new JSDOM();
+  setTheme(dom.window.document, { theme: "light" });
+
+  __expectInsertedLinkElement(dom, "light");
+  __expectUpdatedBody(dom, "light");
+});
+
+test("dark theme is inserted", () => {
+  const dom = new JSDOM();
+  setTheme(dom.window.document, { theme: "dark" });
+
+  __expectInsertedLinkElement(dom, "dark");
+  __expectUpdatedBody(dom, "dark");
+});
+
+test("custom theme is inserted", () => {
+  const dom = new JSDOM();
+  setTheme(dom.window.document, { theme: "custom", customTheme: "body{color:#333;}" });
+
+  __expectInsertedStyleElement(dom, "body{color:#333;}");
+  __expectUpdatedBody(dom, "custom");
+});
+
+test("custom theme fallbacks to light theme if customTheme string is not provided", () => {
+  const customThemes = [undefined, "", "  "]; // all should result in using light theme instead
+  customThemes.forEach((customTheme) => {
+    const dom = new JSDOM();
+    setTheme(dom.window.document, { theme: "custom", customTheme });
+
+    __expectInsertedLinkElement(dom, "light");
+    __expectUpdatedBody(dom, "light");
+  });
+});
+
+test("changing theme should remove the previous theme", () => {
+  const dom = new JSDOM();
+  setTheme(dom.window.document, { theme: "light" }); // inserting light theme first
+  setTheme(dom.window.document, { theme: "dark" }); // then inserting dark theme
+
+  __expectInsertedLinkElement(dom, "dark"); // already tests only 1 theme should be inserted
+  __expectUpdatedBody(dom, "dark");
+});
+
+test("using the same theme again should insert the theme only once", () => {
+  const dom = new JSDOM();
+  setTheme(dom.window.document, { theme: "light" });
+  setTheme(dom.window.document, { theme: "light" });
+
+  __expectInsertedLinkElement(dom, "light"); // already tests only 1 theme should be inserted
+  __expectUpdatedBody(dom, "light");
+});

--- a/src/themes/set-theme.ts
+++ b/src/themes/set-theme.ts
@@ -1,45 +1,49 @@
 import { Theme } from "shared/storage/schema";
 
-const reset = () => {
+const reset = (document: Document) => {
   const elem = document.getElementById("theme");
   elem && elem.remove();
 };
 
-const insertTheme = (theme: Theme) => {
+const appendTheme = (document: Document, element: HTMLLinkElement | HTMLStyleElement, theme: Theme) => {
+  document.head.appendChild(element);
+  document.body.id = theme;
+  document.body.style.opacity = "1";
+};
+
+const insertTheme = (document: Document, theme: Theme) => {
   const link = document.createElement("link");
   link.id = "theme";
   link.rel = "stylesheet";
   link.href = `themes/${theme}.css`;
-  document.getElementsByTagName("head")[0].appendChild(link);
-  document.body.id = theme;
+  appendTheme(document, link, theme);
 };
 
-const insertCustomTheme = (customTheme: string) => {
+const insertCustomTheme = (document: Document, customTheme: string) => {
   const style = document.createElement("style");
   style.id = "theme";
   style.innerHTML = customTheme;
   document.getElementsByTagName("head")[0].appendChild(style);
-  document.body.id = "custom";
+  appendTheme(document, style, "custom");
 };
 
 export interface SetThemeOptions {
-  name: Theme
+  theme: Theme
   customTheme?: string
 }
 
-export default function setTheme({ name, customTheme }: SetThemeOptions): void {
-  reset();
+export function setTheme(document: Document, { theme, customTheme }: SetThemeOptions): void {
+  reset(document);
 
-  if (name === "light" || name === "dark") {
-    insertTheme(name);
+  if (theme === "light" || theme === "dark") {
+    insertTheme(document, theme);
   }
 
-  if (name === "custom") {
+  if (theme === "custom") {
     if (customTheme && customTheme.trim().length > 0) {
-      const protectedCustomTheme = "body{opacity:1;}" + customTheme;
-      insertCustomTheme(protectedCustomTheme);
+      insertCustomTheme(document, customTheme);
     } else {
-      insertTheme("light");
+      insertTheme(document, "light");
     }
   }
 }

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -103,7 +103,3 @@
   --slider-thumb-background-color: white;
   --slider-thumb-size: 12px;
 }
-
-body {
-  opacity: 1;
-}

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -103,7 +103,3 @@
   --slider-thumb-background-color: black;
   --slider-thumb-size: 11px;
 }
-
-body {
-  opacity: 1;
-}


### PR DESCRIPTION
We had `opacity: 1` in themes. It was there to display the content once the data (items from storage) were loaded.

This is now improved and `opacity: 1` is no longer needed by themes. Adding also tests to cement this functionality.