### PR TITLE
Fix Sync Pull Update

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -22,7 +22,10 @@ import {
   saveTextOnRemoteTransfer,
 } from "background/init/saving";
 
-import { handleChangedPermissions } from "background/init/permissions";
+import {
+  handleInitialPermissions,
+  handleChangedPermissions,
+} from "background/init/permissions";
 
 // Run when Installed or Updated
 chrome.runtime.onInstalled.addListener((details) => {
@@ -48,4 +51,5 @@ saveTextOnDrop(); // when you drop text onto a note in Sidebar
 saveTextOnRemoteTransfer(); // when you use "Save to remotely open My Notes" from the context menu
 
 // Permissions
+handleInitialPermissions(); // react to removed permissions between restarts
 handleChangedPermissions(); // react to granted/removed optional permissions "identity" and "alarms"

--- a/src/background/google-drive/sync/__tests__/pull.test.ts
+++ b/src/background/google-drive/sync/__tests__/pull.test.ts
@@ -11,124 +11,124 @@ UPDATED - Update notes name/content if updated in the remote (file.modifiedTime 
 const notes = {
   Article: { // UNCHANGED
     content: "Article content",
-    createdTime: "2020-04-20T09:01:00.000Z",
-    modifiedTime: "2020-04-20T09:01:01.000Z",
+    createdTime: "2020-04-20T09:01:00Z",
+    modifiedTime: "2020-04-20T09:01:01Z",
     sync: {
       file: {
         id: "4360",
         name: "Article",
-        createdTime: "2020-04-20T09:01:00.000Z",
-        modifiedTime: "2020-04-20T09:01:01.000Z",
+        createdTime: "2020-04-20T09:01:00Z",
+        modifiedTime: "2020-04-20T09:01:01Z",
       }
     }
   },
 
   Todo: { // UPDATED (new content only)
     content: "buy milk",
-    createdTime: "2020-04-20T09:02:00.000Z",
-    modifiedTime: "2020-04-20T09:02:02.000Z",
+    createdTime: "2020-04-20T09:02:00Z",
+    modifiedTime: "2020-04-20T09:02:02Z",
     sync: {
       file: {
         id: "6073",
         name: "Todo",
-        createdTime: "2020-04-20T09:02:00.000Z",
-        modifiedTime: "2020-04-20T09:02:02.000Z",
+        createdTime: "2020-04-20T09:02:00Z",
+        modifiedTime: "2020-04-20T09:02:02Z",
       }
     }
   },
 
   Cooking: { // DELETED
     content: "Cooking content",
-    createdTime: "2020-04-20T09:03:00.000Z",
-    modifiedTime: "2020-04-20T09:03:03.000Z",
+    createdTime: "2020-04-20T09:03:00Z",
+    modifiedTime: "2020-04-20T09:03:03Z",
     sync: {
       file: {
         id: "ecb5",
         name: "Cooking",
-        createdTime: "2020-04-20T09:03:00.000Z",
-        modifiedTime: "2020-04-20T09:03:03.000Z",
+        createdTime: "2020-04-20T09:03:00Z",
+        modifiedTime: "2020-04-20T09:03:03Z",
       }
     }
   },
 
   Books: { // UPDATED (new content only)
     content: "The Great Gatsby",
-    createdTime: "2020-04-20T09:04:00.000Z",
-    modifiedTime: "2020-04-20T09:04:04.000Z",
+    createdTime: "2020-04-20T09:04:00Z",
+    modifiedTime: "2020-04-20T09:04:04Z",
     sync: {
       file: {
         id: "9d13",
         name: "Books",
-        createdTime: "2020-04-20T09:04:00.000Z",
-        modifiedTime: "2020-04-20T09:04:04.000Z",
+        createdTime: "2020-04-20T09:04:00Z",
+        modifiedTime: "2020-04-20T09:04:04Z",
       }
     }
   },
 
   Radio: { // UNCHANGED
     content: "some radio stations",
-    createdTime: "2020-04-20T09:05:00.000Z",
-    modifiedTime: "2020-04-20T09:05:05.000Z",
+    createdTime: "2020-04-20T09:05:00Z",
+    modifiedTime: "2020-04-20T09:05:05Z",
   },
 
   Shopping: { // UPDATED (new name AND new content; new name - "Amazon")
     content: "things to buy",
-    createdTime: "2020-04-20T09:06:00.000Z",
-    modifiedTime: "2020-04-20T09:06:06.000Z",
+    createdTime: "2020-04-20T09:06:00Z",
+    modifiedTime: "2020-04-20T09:06:06Z",
     sync: {
       file: {
         id: "df29",
         name: "Shopping",
-        createdTime: "2020-04-20T09:06:00.000Z",
-        modifiedTime: "2020-04-20T09:06:06.000Z",
+        createdTime: "2020-04-20T09:06:00Z",
+        modifiedTime: "2020-04-20T09:06:06Z",
       }
     }
   },
 
   Clipboard: { // DELETED
     content: "Clipboard content",
-    createdTime: "2020-04-20T09:07:00.000Z",
-    modifiedTime: "2020-04-20T09:07:07.000Z",
+    createdTime: "2020-04-20T09:07:00Z",
+    modifiedTime: "2020-04-20T09:07:07Z",
     sync: {
       file: {
         id: "2931",
         name: "Clipboard",
-        createdTime: "2020-04-20T09:07:00.000Z",
-        modifiedTime: "2020-04-20T09:07:07.000Z",
+        createdTime: "2020-04-20T09:07:00Z",
+        modifiedTime: "2020-04-20T09:07:07Z",
       }
     }
   },
 
   News: { // DELETED
     content: "news for today",
-    createdTime: "2020-04-20T09:08:00.000Z",
-    modifiedTime: "2020-04-20T09:08:08.000Z",
+    createdTime: "2020-04-20T09:08:00Z",
+    modifiedTime: "2020-04-20T09:08:08Z",
     sync: {
       file: {
         id: "f745",
         name: "News",
-        createdTime: "2020-04-20T09:08:00.000Z",
-        modifiedTime: "2020-04-20T09:08:08.000Z",
+        createdTime: "2020-04-20T09:08:00Z",
+        modifiedTime: "2020-04-20T09:08:08Z",
       }
     }
   },
 
   Math: { // UPDATED (new content only; name conflict; content should be appended and sync?.file set)
     content: "some equations",
-    createdTime: "2020-04-20T09:09:00.000Z",
-    modifiedTime: "2020-04-20T09:09:09.000Z",
+    createdTime: "2020-04-20T09:09:00Z",
+    modifiedTime: "2020-04-20T09:09:09Z",
   },
 
   Vacation: { // UPDATED (new name AND new content; new name - "Trip")
     content: "places to go",
-    createdTime: "2020-04-20T09:10:00.000Z",
-    modifiedTime: "2020-04-20T09:10:10.000Z",
+    createdTime: "2020-04-20T09:10:00Z",
+    modifiedTime: "2020-04-20T09:10:10Z",
     sync: {
       file: {
         id: "9e0e",
         name: "Vacation",
-        createdTime: "2020-04-20T09:10:00.000Z",
-        modifiedTime: "2020-04-20T09:10:10.000Z",
+        createdTime: "2020-04-20T09:10:00Z",
+        modifiedTime: "2020-04-20T09:10:10Z",
       }
     }
   }
@@ -141,15 +141,15 @@ const notes = {
 
 const files = [
   // UNCHANGED (either not having a file, or file.modifiedTime is unchanged)
-  { id: "4360", name: "Article", createdTime: "2020-04-20T09:01:00.000Z", modifiedTime: "2020-04-20T09:01:01.000Z" },
+  { id: "4360", name: "Article", createdTime: "2020-04-20T09:01:00Z", modifiedTime: "2020-04-20T09:01:01Z" },
   // "Radio"
 
   // UPDATED
-  { id: "6073", name: "Todo", createdTime: "2020-04-20T09:02:00.000Z", modifiedTime: "2020-04-20T09:02:07.000Z" },
-  { id: "9d13", name: "Books", createdTime: "2020-04-20T09:04:00.000Z", modifiedTime: "2020-04-20T09:04:09.000Z" },
-  { id: "df29", name: "Amazon", createdTime: "2020-04-20T09:06:00.000Z", modifiedTime: "2020-04-20T09:06:11.000Z" }, // before "Shopping"
-  { id: "777f", name: "Math", createdTime: "2020-04-20T09:25:00.000Z", modifiedTime: "2020-04-20T09:25:25.000Z" }, // name conflict = add content to existing note
-  { id: "9e0e", name: "Trip", createdTime: "2020-04-20T09:10:00.000Z", modifiedTime: "2020-04-20T09:10:15.000Z" }, // before "Vacation"
+  { id: "6073", name: "Todo", createdTime: "2020-04-20T09:02:00Z", modifiedTime: "2020-04-20T09:02:07Z" },
+  { id: "9d13", name: "Books", createdTime: "2020-04-20T09:04:00Z", modifiedTime: "2020-04-20T09:04:09Z" },
+  { id: "df29", name: "Amazon", createdTime: "2020-04-20T09:06:00Z", modifiedTime: "2020-04-20T09:06:11Z" }, // before "Shopping"
+  { id: "777f", name: "Math", createdTime: "2020-04-20T09:25:00Z", modifiedTime: "2020-04-20T09:25:25Z" }, // name conflict = add content to existing note
+  { id: "9e0e", name: "Trip", createdTime: "2020-04-20T09:10:00Z", modifiedTime: "2020-04-20T09:10:15Z" }, // before "Vacation"
 
   // DELETED
   // { id: "ecb5", ... } // "Cooking"
@@ -157,9 +157,9 @@ const files = [
   // { id: "2931", ... } // "Clipboard"
 
   // NEW
-  { id: "2b18", name: "Phones", createdTime: "2020-04-20T09:11:00.000Z", modifiedTime: "2020-04-20T09:11:11.000Z" },
-  { id: "0dc9", name: "TV", createdTime: "2020-04-20T09:12:00.000Z", modifiedTime: "2020-04-20T09:12:12.000Z" },
-  { id: "b378", name: "Lamps", createdTime: "2020-04-20T09:13:00.000Z", modifiedTime: "2020-04-20T09:13:13.000Z" },
+  { id: "2b18", name: "Phones", createdTime: "2020-04-20T09:11:00Z", modifiedTime: "2020-04-20T09:11:11Z" },
+  { id: "0dc9", name: "TV", createdTime: "2020-04-20T09:12:00Z", modifiedTime: "2020-04-20T09:12:12Z" },
+  { id: "b378", name: "Lamps", createdTime: "2020-04-20T09:13:00Z", modifiedTime: "2020-04-20T09:13:13Z" },
 ];
 
 const getFile = (fileId: string): Promise<string> => Promise.resolve(`CONTENT OF ${fileId}`);
@@ -171,22 +171,22 @@ it("pulls new and updated notes, and deletes notes if deleted in Google Drive", 
 
   // Article
   expect(updatedNotes.Article.content === "Article content");
-  expect(updatedNotes.Article.createdTime === "2020-04-20T09:01:00.000Z");
-  expect(updatedNotes.Article.modifiedTime === "2020-04-20T09:01:01.000Z");
+  expect(updatedNotes.Article.createdTime === "2020-04-20T09:01:00Z");
+  expect(updatedNotes.Article.modifiedTime === "2020-04-20T09:01:01Z");
   expect(updatedNotes.Article.sync?.file.id === "4360");
   expect(updatedNotes.Article.sync?.file.name === "Article");
-  expect(updatedNotes.Article.sync?.file.createdTime === "2020-04-20T09:01:00.000Z");
-  expect(updatedNotes.Article.sync?.file.modifiedTime === "2020-04-20T09:01:01.000Z");
+  expect(updatedNotes.Article.sync?.file.createdTime === "2020-04-20T09:01:00Z");
+  expect(updatedNotes.Article.sync?.file.modifiedTime === "2020-04-20T09:01:01Z");
   expect(Object.keys(updatedNotes.Article.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // Todo
   expect(updatedNotes.Todo.content === "CONTENT OF 6073");
-  expect(updatedNotes.Todo.createdTime === "2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.modifiedTime === "2020-04-20T09:02:07.000Z");
+  expect(updatedNotes.Todo.createdTime === "2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.modifiedTime === "2020-04-20T09:02:07Z");
   expect(updatedNotes.Todo.sync?.file.id === "6073");
   expect(updatedNotes.Todo.sync?.file.name === "Todo");
-  expect(updatedNotes.Todo.sync?.file.createdTime === "2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.sync?.file.modifiedTime === "2020-04-20T09:02:07.000Z");
+  expect(updatedNotes.Todo.sync?.file.createdTime === "2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.sync?.file.modifiedTime === "2020-04-20T09:02:07Z");
   expect(Object.keys(updatedNotes.Todo.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // deleted Cooking
@@ -194,28 +194,28 @@ it("pulls new and updated notes, and deletes notes if deleted in Google Drive", 
 
   // Books
   expect(updatedNotes.Books.content === "CONTENT OF 9d13");
-  expect(updatedNotes.Books.createdTime === "2020-04-20T09:04:00.000Z");
-  expect(updatedNotes.Books.modifiedTime === "2020-04-20T09:04:09.000Z");
+  expect(updatedNotes.Books.createdTime === "2020-04-20T09:04:00Z");
+  expect(updatedNotes.Books.modifiedTime === "2020-04-20T09:04:09Z");
   expect(updatedNotes.Books.sync?.file.id === "9d13");
   expect(updatedNotes.Books.sync?.file.name === "Books");
-  expect(updatedNotes.Books.sync?.file.createdTime === "2020-04-20T09:04:00.000Z");
-  expect(updatedNotes.Books.sync?.file.modifiedTime === "2020-04-20T09:04:09.000Z");
+  expect(updatedNotes.Books.sync?.file.createdTime === "2020-04-20T09:04:00Z");
+  expect(updatedNotes.Books.sync?.file.modifiedTime === "2020-04-20T09:04:09Z");
   expect(Object.keys(updatedNotes.Books.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // Radio
   expect(updatedNotes.Radio.content === "some radio stations");
-  expect(updatedNotes.Radio.createdTime === "2020-04-20T09:05:00.000Z");
-  expect(updatedNotes.Radio.modifiedTime === "2020-04-20T09:05:05.000Z");
+  expect(updatedNotes.Radio.createdTime === "2020-04-20T09:05:00Z");
+  expect(updatedNotes.Radio.modifiedTime === "2020-04-20T09:05:05Z");
   expect("sync" in updatedNotes.Radio === false);
 
   // Amazon (before "Shopping")
   expect(updatedNotes.Amazon.content === "CONTENT OF df29");
-  expect(updatedNotes.Amazon.createdTime === "2020-04-20T09:06:00.000Z");
-  expect(updatedNotes.Amazon.modifiedTime === "2020-04-20T09:06:11.000Z");
+  expect(updatedNotes.Amazon.createdTime === "2020-04-20T09:06:00Z");
+  expect(updatedNotes.Amazon.modifiedTime === "2020-04-20T09:06:11Z");
   expect(updatedNotes.Amazon.sync?.file.id === "df29");
   expect(updatedNotes.Amazon.sync?.file.name === "Amazon");
-  expect(updatedNotes.Amazon.sync?.file.createdTime === "2020-04-20T09:06:00.000Z");
-  expect(updatedNotes.Amazon.sync?.file.modifiedTime === "2020-04-20T09:06:11.000Z");
+  expect(updatedNotes.Amazon.sync?.file.createdTime === "2020-04-20T09:06:00Z");
+  expect(updatedNotes.Amazon.sync?.file.modifiedTime === "2020-04-20T09:06:11Z");
   expect(Object.keys(updatedNotes.Amazon.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
   expect("Shopping" in updatedNotes === false); // renamed to "Amazon"
 
@@ -227,53 +227,53 @@ it("pulls new and updated notes, and deletes notes if deleted in Google Drive", 
 
   // Math
   expect(updatedNotes.Math.content === "some equations<br><br>CONTENT OF 777f");
-  expect(updatedNotes.Math.createdTime === "2020-04-20T09:25:00.000Z");
-  expect(updatedNotes.Math.modifiedTime === "2020-04-20T09:25:25.000Z");
+  expect(updatedNotes.Math.createdTime === "2020-04-20T09:25:00Z");
+  expect(updatedNotes.Math.modifiedTime === "2020-04-20T09:25:25Z");
   expect(updatedNotes.Math.sync?.file.id === "777f");
   expect(updatedNotes.Math.sync?.file.name === "Math");
-  expect(updatedNotes.Math.sync?.file.createdTime === "2020-04-20T09:25:00.000Z");
-  expect(updatedNotes.Math.sync?.file.modifiedTime === "2020-04-20T09:25:25.000Z");
+  expect(updatedNotes.Math.sync?.file.createdTime === "2020-04-20T09:25:00Z");
+  expect(updatedNotes.Math.sync?.file.modifiedTime === "2020-04-20T09:25:25Z");
   expect(Object.keys(updatedNotes.Math.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // Trip (before "Vacation")
   expect(updatedNotes.Trip.content === "CONTENT OF 9e0e");
-  expect(updatedNotes.Trip.createdTime === "2020-04-20T09:10:00.000Z");
-  expect(updatedNotes.Trip.modifiedTime === "2020-04-20T09:10:15.000Z");
+  expect(updatedNotes.Trip.createdTime === "2020-04-20T09:10:00Z");
+  expect(updatedNotes.Trip.modifiedTime === "2020-04-20T09:10:15Z");
   expect(updatedNotes.Trip.sync?.file.id === "9e0e");
   expect(updatedNotes.Trip.sync?.file.name === "Trip");
-  expect(updatedNotes.Trip.sync?.file.createdTime === "2020-04-20T09:10:00.000Z");
-  expect(updatedNotes.Trip.sync?.file.modifiedTime === "2020-04-20T09:10:15.000Z");
+  expect(updatedNotes.Trip.sync?.file.createdTime === "2020-04-20T09:10:00Z");
+  expect(updatedNotes.Trip.sync?.file.modifiedTime === "2020-04-20T09:10:15Z");
   expect(Object.keys(updatedNotes.Trip.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
   expect("Vacation" in updatedNotes === false); // renamed to "Trip"
 
   // Phones
   expect(updatedNotes.Phones.content === "CONTENT OF 2b18");
-  expect(updatedNotes.Phones.createdTime === "2020-04-20T09:11:00.000Z");
-  expect(updatedNotes.Phones.modifiedTime === "2020-04-20T09:11:11.000Z");
+  expect(updatedNotes.Phones.createdTime === "2020-04-20T09:11:00Z");
+  expect(updatedNotes.Phones.modifiedTime === "2020-04-20T09:11:11Z");
   expect(updatedNotes.Phones.sync?.file.id === "2b18");
   expect(updatedNotes.Phones.sync?.file.name === "Phones");
-  expect(updatedNotes.Phones.sync?.file.createdTime === "2020-04-20T09:11:00.000Z");
-  expect(updatedNotes.Phones.sync?.file.modifiedTime === "2020-04-20T09:11:11.000Z");
+  expect(updatedNotes.Phones.sync?.file.createdTime === "2020-04-20T09:11:00Z");
+  expect(updatedNotes.Phones.sync?.file.modifiedTime === "2020-04-20T09:11:11Z");
   expect(Object.keys(updatedNotes.Phones.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // TV
   expect(updatedNotes.TV.content === "CONTENT OF 0dc9");
-  expect(updatedNotes.TV.createdTime === "2020-04-20T09:12:00.000Z");
-  expect(updatedNotes.TV.modifiedTime === "2020-04-20T09:12:12.000Z");
+  expect(updatedNotes.TV.createdTime === "2020-04-20T09:12:00Z");
+  expect(updatedNotes.TV.modifiedTime === "2020-04-20T09:12:12Z");
   expect(updatedNotes.TV.sync?.file.id === "0dc9");
   expect(updatedNotes.TV.sync?.file.name === "TV");
-  expect(updatedNotes.TV.sync?.file.createdTime === "2020-04-20T09:12:00.000Z");
-  expect(updatedNotes.TV.sync?.file.modifiedTime === "2020-04-20T09:12:12.000Z");
+  expect(updatedNotes.TV.sync?.file.createdTime === "2020-04-20T09:12:00Z");
+  expect(updatedNotes.TV.sync?.file.modifiedTime === "2020-04-20T09:12:12Z");
   expect(Object.keys(updatedNotes.TV.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // Lamps
   expect(updatedNotes.Lamps.content === "CONTENT OF b378");
-  expect(updatedNotes.Lamps.createdTime === "2020-04-20T09:13:00.000Z");
-  expect(updatedNotes.Lamps.modifiedTime === "2020-04-20T09:13:13.000Z");
+  expect(updatedNotes.Lamps.createdTime === "2020-04-20T09:13:00Z");
+  expect(updatedNotes.Lamps.modifiedTime === "2020-04-20T09:13:13Z");
   expect(updatedNotes.Lamps.sync?.file.id === "b378");
   expect(updatedNotes.Lamps.sync?.file.name === "Lamps");
-  expect(updatedNotes.Lamps.sync?.file.createdTime === "2020-04-20T09:13:00.000Z");
-  expect(updatedNotes.Lamps.sync?.file.modifiedTime === "2020-04-20T09:13:13.000Z");
+  expect(updatedNotes.Lamps.sync?.file.createdTime === "2020-04-20T09:13:00Z");
+  expect(updatedNotes.Lamps.sync?.file.modifiedTime === "2020-04-20T09:13:13Z");
   expect(Object.keys(updatedNotes.Lamps.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 });
 
@@ -284,22 +284,22 @@ it("links notes to files with same name in Google Drive", async () => {
   const notes = {
     Todo: {
       content: "buy milk",
-      createdTime: "2020-04-20T09:02:00.000Z",
-      modifiedTime: "2020-04-20T09:02:02.000Z",
+      createdTime: "2020-04-20T09:02:00Z",
+      modifiedTime: "2020-04-20T09:02:02Z",
     },
     Clipboard: {
       content: "my clipboard",
-      createdTime: "2020-04-20T09:07:00.000Z",
-      modifiedTime: "2020-04-20T09:07:07.000Z",
+      createdTime: "2020-04-20T09:07:00Z",
+      modifiedTime: "2020-04-20T09:07:07Z",
     },
   };
 
   const files = [
     // SAME modifiedTime
-    { id: "6073", name: "Todo", createdTime: "2020-04-20T09:02:00.000Z", modifiedTime: "2020-04-20T09:02:02.000Z" },
+    { id: "6073", name: "Todo", createdTime: "2020-04-20T09:02:00Z", modifiedTime: "2020-04-20T09:02:02Z" },
 
     // UPDATED
-    { id: "2931", name: "Clipboard", createdTime: "2020-04-20T09:07:00.000Z", modifiedTime: "2020-04-20T09:07:12.000Z" },
+    { id: "2931", name: "Clipboard", createdTime: "2020-04-20T09:07:00Z", modifiedTime: "2020-04-20T09:07:12Z" },
   ];
 
   const updatedNotes = await pull(notes, files, { getFile });
@@ -308,22 +308,22 @@ it("links notes to files with same name in Google Drive", async () => {
 
   // Todo
   expect(updatedNotes.Todo.content === "buy milk"); // unchanged
-  expect(updatedNotes.Todo.createdTime === "2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.modifiedTime === "2020-04-20T09:02:02.000Z");
+  expect(updatedNotes.Todo.createdTime === "2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.modifiedTime === "2020-04-20T09:02:02Z");
   expect(updatedNotes.Todo.sync?.file.id === "6073");
   expect(updatedNotes.Todo.sync?.file.name === "Todo");
-  expect(updatedNotes.Todo.sync?.file.createdTime === "2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.sync?.file.modifiedTime === "2020-04-20T09:02:02.000Z");
+  expect(updatedNotes.Todo.sync?.file.createdTime === "2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.sync?.file.modifiedTime === "2020-04-20T09:02:02Z");
   expect(Object.keys(updatedNotes.Todo.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // Clipboard
   expect(updatedNotes.Clipboard.content === "my clipboard<br><br>CONTENT OF 2931"); // appended (not replaced)
-  expect(updatedNotes.Clipboard.createdTime === "2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.modifiedTime === "2020-04-20T09:07:12.000Z");
+  expect(updatedNotes.Clipboard.createdTime === "2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.modifiedTime === "2020-04-20T09:07:12Z");
   expect(updatedNotes.Clipboard.sync?.file.id === "2931");
   expect(updatedNotes.Clipboard.sync?.file.name === "Clipboard");
-  expect(updatedNotes.Clipboard.sync?.file.createdTime === "2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.sync?.file.modifiedTime === "2020-04-20T09:07:12.000Z");
+  expect(updatedNotes.Clipboard.sync?.file.createdTime === "2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.sync?.file.modifiedTime === "2020-04-20T09:07:12Z");
   expect(Object.keys(updatedNotes.Clipboard.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 });
 
@@ -331,22 +331,22 @@ it("links notes to the last file in Google Drive if having the same name in Goog
   const notes = {
     Todo: {
       content: "buy milk",
-      createdTime: "2020-04-20T09:02:00.000Z",
-      modifiedTime: "2020-04-20T09:02:02.000Z",
+      createdTime: "2020-04-20T09:02:00Z",
+      modifiedTime: "2020-04-20T09:02:02Z",
     },
     Clipboard: {
       content: "my clipboard",
-      createdTime: "2020-04-20T09:07:00.000Z",
-      modifiedTime: "2020-04-20T09:07:07.000Z",
+      createdTime: "2020-04-20T09:07:00Z",
+      modifiedTime: "2020-04-20T09:07:07Z",
     },
   };
 
   const files = [
     // "Todo" renamed to "Clipboard" (UPDATED)
-    { id: "6073", name: "Clipboard", createdTime: "2020-04-20T09:02:00.000Z", modifiedTime: "2020-04-20T09:07:17.000Z" },
+    { id: "6073", name: "Clipboard", createdTime: "2020-04-20T09:02:00Z", modifiedTime: "2020-04-20T09:07:17Z" },
 
     // "Clipboard" (UPDATED)
-    { id: "2931", name: "Clipboard", createdTime: "2020-04-20T09:07:00.000Z", modifiedTime: "2020-04-20T09:07:12.000Z" },
+    { id: "2931", name: "Clipboard", createdTime: "2020-04-20T09:07:00Z", modifiedTime: "2020-04-20T09:07:12Z" },
   ];
 
   const updatedNotes = await pull(notes, files, { getFile });
@@ -355,18 +355,18 @@ it("links notes to the last file in Google Drive if having the same name in Goog
 
   // Todo
   expect(updatedNotes.Todo.content === "buy milk");
-  expect(updatedNotes.Todo.createdTime === "2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.modifiedTime === "2020-04-20T09:02:02.000Z");
+  expect(updatedNotes.Todo.createdTime === "2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.modifiedTime === "2020-04-20T09:02:02Z");
   expect("sync" in updatedNotes.Todo === false);
 
   // Clipboard (last file with the same name used)
   expect(updatedNotes.Clipboard.content === "CONTENT OF 2931");
-  expect(updatedNotes.Clipboard.createdTime === "2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.modifiedTime === "2020-04-20T09:07:12.000Z");
+  expect(updatedNotes.Clipboard.createdTime === "2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.modifiedTime === "2020-04-20T09:07:12Z");
   expect(updatedNotes.Clipboard.sync?.file.id === "2931");
   expect(updatedNotes.Clipboard.sync?.file.name === "Clipboard");
-  expect(updatedNotes.Clipboard.sync?.file.createdTime === "2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.sync?.file.modifiedTime === "2020-04-20T09:07:12.000Z");
+  expect(updatedNotes.Clipboard.sync?.file.createdTime === "2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.sync?.file.modifiedTime === "2020-04-20T09:07:12Z");
   expect(Object.keys(updatedNotes.Clipboard.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 });
 
@@ -376,27 +376,27 @@ it("renames the note if linked but renamed in Google Drive", async () => {
   const notes = {
     Cooking: { // renamed since last sync (before: "Kitchen")
       content: "Cooking content",
-      createdTime: "2020-04-20T09:03:00.000Z",
-      modifiedTime: "2020-04-20T09:03:08.000Z",
+      createdTime: "2020-04-20T09:03:00Z",
+      modifiedTime: "2020-04-20T09:03:08Z",
       sync: {
         file: {
           id: "ecb5",
           name: "Kitchen",
-          createdTime: "2020-04-20T09:03:00.000Z",
-          modifiedTime: "2020-04-20T09:03:03.000Z",
+          createdTime: "2020-04-20T09:03:00Z",
+          modifiedTime: "2020-04-20T09:03:03Z",
         }
       }
     },
     Clipboard: {
       content: "my clipboard",
-      createdTime: "2020-04-20T09:07:00.000Z",
-      modifiedTime: "2020-04-20T09:07:07.000Z",
+      createdTime: "2020-04-20T09:07:00Z",
+      modifiedTime: "2020-04-20T09:07:07Z",
     },
   };
 
   const files = [
     // UPDATED, renamed as well
-    { id: "ecb5", name: "Recipes", createdTime: "2020-04-20T09:03:00.000Z", modifiedTime: "2020-04-20T09:03:13.000Z" },
+    { id: "ecb5", name: "Recipes", createdTime: "2020-04-20T09:03:00Z", modifiedTime: "2020-04-20T09:03:13Z" },
   ];
 
   const updatedNotes = await pull(notes, files, { getFile });
@@ -405,17 +405,17 @@ it("renames the note if linked but renamed in Google Drive", async () => {
 
   // Recipes
   expect(updatedNotes.Recipes.content === "CONTENT OF ecb5");
-  expect(updatedNotes.Recipes.createdTime === "2020-04-20T09:03:00.000Z");
-  expect(updatedNotes.Recipes.modifiedTime === "2020-04-20T09:03:13.000Z");
+  expect(updatedNotes.Recipes.createdTime === "2020-04-20T09:03:00Z");
+  expect(updatedNotes.Recipes.modifiedTime === "2020-04-20T09:03:13Z");
   expect(updatedNotes.Recipes.sync?.file.id === "ecb5");
   expect(updatedNotes.Recipes.sync?.file.name === "Recipes");
-  expect(updatedNotes.Recipes.sync?.file.createdTime === "2020-04-20T09:03:00.000Z");
-  expect(updatedNotes.Recipes.sync?.file.modifiedTime === "2020-04-20T09:03:13.000Z");
+  expect(updatedNotes.Recipes.sync?.file.createdTime === "2020-04-20T09:03:00Z");
+  expect(updatedNotes.Recipes.sync?.file.modifiedTime === "2020-04-20T09:03:13Z");
   expect(Object.keys(updatedNotes.Recipes.sync?.file || {}).length === 4); // { id, name, createdTime, modifiedTime }
 
   // Clipboard
   expect(updatedNotes.Clipboard.content === "my clipboard");
-  expect(updatedNotes.Clipboard.createdTime === "2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.modifiedTime === "2020-04-20T09:07:07.000Z");
+  expect(updatedNotes.Clipboard.createdTime === "2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.modifiedTime === "2020-04-20T09:07:07Z");
   expect("sync" in updatedNotes.Clipboard === false);
 });

--- a/src/background/google-drive/sync/__tests__/push.test.ts
+++ b/src/background/google-drive/sync/__tests__/push.test.ts
@@ -11,70 +11,70 @@ UPDATED - Update file name/content for every updated note (note with "sync", whe
 const notes = {
   Clipboard: { // UNCHANGED
     content: "Clipboard content",
-    createdTime: "2020-04-20T09:07:00.000Z",
-    modifiedTime: "2020-04-20T09:07:07.000Z",
+    createdTime: "2020-04-20T09:07:00Z",
+    modifiedTime: "2020-04-20T09:07:07Z",
     sync: {
       file: {
         id: "2931",
         name: "Clipboard",
-        createdTime: "2020-04-20T09:07:00.000Z",
-        modifiedTime: "2020-04-20T09:07:07.000Z",
+        createdTime: "2020-04-20T09:07:00Z",
+        modifiedTime: "2020-04-20T09:07:07Z",
       }
     }
   },
 
   Radio: { // NEW
     content: "some radio stations",
-    createdTime: "2020-04-20T09:05:00.000Z",
-    modifiedTime: "2020-04-20T09:05:05.000Z",
+    createdTime: "2020-04-20T09:05:00Z",
+    modifiedTime: "2020-04-20T09:05:05Z",
   },
 
   Todo: { // UPDATED
     content: "buy milk, buy coffee",
-    createdTime: "2020-04-20T09:02:00.000Z",
-    modifiedTime: "2020-04-20T09:02:07.000Z", // +5 seconds
+    createdTime: "2020-04-20T09:02:00Z",
+    modifiedTime: "2020-04-20T09:02:07Z", // +5 seconds
     sync: {
       file: {
         id: "6073",
         name: "Todo",
-        createdTime: "2020-04-20T09:02:00.000Z",
-        modifiedTime: "2020-04-20T09:02:02.000Z",
+        createdTime: "2020-04-20T09:02:00Z",
+        modifiedTime: "2020-04-20T09:02:02Z",
       }
     }
   },
 
   Books: { // UNCHANGED
     content: "The Great Gatsby",
-    createdTime: "2020-04-20T09:04:00.000Z",
-    modifiedTime: "2020-04-20T09:04:04.000Z",
+    createdTime: "2020-04-20T09:04:00Z",
+    modifiedTime: "2020-04-20T09:04:04Z",
     sync: {
       file: {
         id: "9d13",
         name: "Books",
-        createdTime: "2020-04-20T09:04:00.000Z",
-        modifiedTime: "2020-04-20T09:04:04.000Z",
+        createdTime: "2020-04-20T09:04:00Z",
+        modifiedTime: "2020-04-20T09:04:04Z",
       }
     }
   },
 
   Amazon: { // UPDATED (also new name; name before - "Shopping")
     content: "things to buy, more things to buy",
-    createdTime: "2020-04-20T09:06:00.000Z",
-    modifiedTime: "2020-04-20T09:06:11.000Z", // +5 seconds
+    createdTime: "2020-04-20T09:06:00Z",
+    modifiedTime: "2020-04-20T09:06:11Z", // +5 seconds
     sync: {
       file: {
         id: "df29",
         name: "Shopping",
-        createdTime: "2020-04-20T09:06:00.000Z",
-        modifiedTime: "2020-04-20T09:06:06.000Z",
+        createdTime: "2020-04-20T09:06:00Z",
+        modifiedTime: "2020-04-20T09:06:06Z",
       }
     }
   },
 
   Math: { // NEW
     content: "some equations",
-    createdTime: "2020-04-20T09:09:00.000Z",
-    modifiedTime: "2020-04-20T09:09:09.000Z",
+    createdTime: "2020-04-20T09:09:00Z",
+    modifiedTime: "2020-04-20T09:09:09Z",
   },
 };
 
@@ -88,61 +88,61 @@ it("pushes new and updated notes", async () => {
 
   // Clipboard (UNCHANGED)
   expect(updatedNotes.Clipboard.content).toBe("Clipboard content");
-  expect(updatedNotes.Clipboard.createdTime).toBe("2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.modifiedTime).toBe("2020-04-20T09:07:07.000Z");
+  expect(updatedNotes.Clipboard.createdTime).toBe("2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.modifiedTime).toBe("2020-04-20T09:07:07Z");
   expect(updatedNotes.Clipboard.sync?.file.id).toBe("2931");
   expect(updatedNotes.Clipboard.sync?.file.name).toBe("Clipboard");
-  expect(updatedNotes.Clipboard.sync?.file.createdTime).toBe("2020-04-20T09:07:00.000Z");
-  expect(updatedNotes.Clipboard.sync?.file.modifiedTime).toBe("2020-04-20T09:07:07.000Z");
+  expect(updatedNotes.Clipboard.sync?.file.createdTime).toBe("2020-04-20T09:07:00Z");
+  expect(updatedNotes.Clipboard.sync?.file.modifiedTime).toBe("2020-04-20T09:07:07Z");
   expect(Object.keys(updatedNotes.Clipboard.sync?.file || {}).length).toBe(4); // { id, name, createdTime, modifiedTime }
 
   // Radio (NEW)
   expect(updatedNotes.Radio.content).toBe("some radio stations");
-  expect(updatedNotes.Radio.createdTime).toBe("2020-04-20T09:05:00.000Z");
-  expect(updatedNotes.Radio.modifiedTime).toBe("2020-04-20T09:05:05.000Z");
+  expect(updatedNotes.Radio.createdTime).toBe("2020-04-20T09:05:00Z");
+  expect(updatedNotes.Radio.modifiedTime).toBe("2020-04-20T09:05:05Z");
   expect(updatedNotes.Radio.sync?.file.id).toBe("450e390a-Radio-created");
   expect(updatedNotes.Radio.sync?.file.name).toBe("Radio");
-  expect(updatedNotes.Radio.sync?.file.createdTime).toBe("2020-04-20T09:05:00.000Z");
-  expect(updatedNotes.Radio.sync?.file.modifiedTime).toBe("2020-04-20T09:05:05.000Z");
+  expect(updatedNotes.Radio.sync?.file.createdTime).toBe("2020-04-20T09:05:00Z");
+  expect(updatedNotes.Radio.sync?.file.modifiedTime).toBe("2020-04-20T09:05:05Z");
   expect(Object.keys(updatedNotes.Radio.sync?.file || {}).length).toBe(4); // { id, name, createdTime, modifiedTime }
 
   // Todo (UPDATED)
   expect(updatedNotes.Todo.content).toBe("buy milk, buy coffee");
-  expect(updatedNotes.Todo.createdTime).toBe("2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.modifiedTime).toBe("2020-04-20T09:02:07.000Z");
+  expect(updatedNotes.Todo.createdTime).toBe("2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.modifiedTime).toBe("2020-04-20T09:02:07Z");
   expect(updatedNotes.Todo.sync?.file.id).toBe("6073-Todo-updated");
   expect(updatedNotes.Todo.sync?.file.name).toBe("Todo");
-  expect(updatedNotes.Todo.sync?.file.createdTime).toBe("2020-04-20T09:02:00.000Z");
-  expect(updatedNotes.Todo.sync?.file.modifiedTime).toBe("2020-04-20T09:02:07.000Z");
+  expect(updatedNotes.Todo.sync?.file.createdTime).toBe("2020-04-20T09:02:00Z");
+  expect(updatedNotes.Todo.sync?.file.modifiedTime).toBe("2020-04-20T09:02:07Z");
   expect(Object.keys(updatedNotes.Todo.sync?.file || {}).length).toBe(4); // { id, name, createdTime, modifiedTime }
 
   // Books (UNCHANGED)
   expect(updatedNotes.Books.content).toBe("The Great Gatsby");
-  expect(updatedNotes.Books.createdTime).toBe("2020-04-20T09:04:00.000Z");
-  expect(updatedNotes.Books.modifiedTime).toBe("2020-04-20T09:04:04.000Z");
+  expect(updatedNotes.Books.createdTime).toBe("2020-04-20T09:04:00Z");
+  expect(updatedNotes.Books.modifiedTime).toBe("2020-04-20T09:04:04Z");
   expect(updatedNotes.Books.sync?.file.id).toBe("9d13");
   expect(updatedNotes.Books.sync?.file.name).toBe("Books");
-  expect(updatedNotes.Books.sync?.file.createdTime).toBe("2020-04-20T09:04:00.000Z");
-  expect(updatedNotes.Books.sync?.file.modifiedTime).toBe("2020-04-20T09:04:04.000Z");
+  expect(updatedNotes.Books.sync?.file.createdTime).toBe("2020-04-20T09:04:00Z");
+  expect(updatedNotes.Books.sync?.file.modifiedTime).toBe("2020-04-20T09:04:04Z");
   expect(Object.keys(updatedNotes.Books.sync?.file || {}).length).toBe(4); // { id, name, createdTime, modifiedTime }
 
   // Amazon (UPDATED, file.name before - "Shopping")
   expect(updatedNotes.Amazon.content).toBe("things to buy, more things to buy");
-  expect(updatedNotes.Amazon.createdTime).toBe("2020-04-20T09:06:00.000Z");
-  expect(updatedNotes.Amazon.modifiedTime).toBe("2020-04-20T09:06:11.000Z");
+  expect(updatedNotes.Amazon.createdTime).toBe("2020-04-20T09:06:00Z");
+  expect(updatedNotes.Amazon.modifiedTime).toBe("2020-04-20T09:06:11Z");
   expect(updatedNotes.Amazon.sync?.file.id).toBe("df29-Amazon-updated");
   expect(updatedNotes.Amazon.sync?.file.name).toBe("Amazon"); // before "Shopping"
-  expect(updatedNotes.Amazon.sync?.file.createdTime).toBe("2020-04-20T09:06:00.000Z");
-  expect(updatedNotes.Amazon.sync?.file.modifiedTime).toBe("2020-04-20T09:06:11.000Z");
+  expect(updatedNotes.Amazon.sync?.file.createdTime).toBe("2020-04-20T09:06:00Z");
+  expect(updatedNotes.Amazon.sync?.file.modifiedTime).toBe("2020-04-20T09:06:11Z");
   expect(Object.keys(updatedNotes.Amazon.sync?.file || {}).length).toBe(4); // { id, name, createdTime, modifiedTime }
 
   // Math (NEW)
   expect(updatedNotes.Math.content).toBe("some equations");
-  expect(updatedNotes.Math.createdTime).toBe("2020-04-20T09:09:00.000Z");
-  expect(updatedNotes.Math.modifiedTime).toBe("2020-04-20T09:09:09.000Z");
+  expect(updatedNotes.Math.createdTime).toBe("2020-04-20T09:09:00Z");
+  expect(updatedNotes.Math.modifiedTime).toBe("2020-04-20T09:09:09Z");
   expect(updatedNotes.Math.sync?.file.id).toBe("450e390a-Math-created");
   expect(updatedNotes.Math.sync?.file.name).toBe("Math");
-  expect(updatedNotes.Math.sync?.file.createdTime).toBe("2020-04-20T09:09:00.000Z");
-  expect(updatedNotes.Math.sync?.file.modifiedTime).toBe("2020-04-20T09:09:09.000Z");
+  expect(updatedNotes.Math.sync?.file.createdTime).toBe("2020-04-20T09:09:00Z");
+  expect(updatedNotes.Math.sync?.file.modifiedTime).toBe("2020-04-20T09:09:09Z");
   expect(Object.keys(updatedNotes.Math.sync?.file || {}).length).toBe(4); // { id, name, createdTime, modifiedTime }
 });

--- a/src/background/google-drive/sync/__tests__/stop.test.ts
+++ b/src/background/google-drive/sync/__tests__/stop.test.ts
@@ -3,34 +3,34 @@ import { unlinkNotes } from "../stop";
 const notes = {
   Clipboard: {
     content: "Clipboard content",
-    createdTime: "2020-04-20T09:07:00.000Z",
-    modifiedTime: "2020-04-20T09:07:07.000Z",
+    createdTime: "2020-04-20T09:07:00Z",
+    modifiedTime: "2020-04-20T09:07:07Z",
     sync: {
       file: {
         id: "2931",
         name: "Clipboard",
-        createdTime: "2020-04-20T09:07:00.000Z",
-        modifiedTime: "2020-04-20T09:07:07.000Z",
+        createdTime: "2020-04-20T09:07:00Z",
+        modifiedTime: "2020-04-20T09:07:07Z",
       }
     }
   },
 
   Radio: {
     content: "some radio stations",
-    createdTime: "2020-04-20T09:05:00.000Z",
-    modifiedTime: "2020-04-20T09:05:05.000Z",
+    createdTime: "2020-04-20T09:05:00Z",
+    modifiedTime: "2020-04-20T09:05:05Z",
   },
 
   Todo: {
     content: "buy milk, buy coffee",
-    createdTime: "2020-04-20T09:02:00.000Z",
-    modifiedTime: "2020-04-20T09:02:07.000Z",
+    createdTime: "2020-04-20T09:02:00Z",
+    modifiedTime: "2020-04-20T09:02:07Z",
     sync: {
       file: {
         id: "6073",
         name: "Todo",
-        createdTime: "2020-04-20T09:02:00.000Z",
-        modifiedTime: "2020-04-20T09:02:02.000Z",
+        createdTime: "2020-04-20T09:02:00Z",
+        modifiedTime: "2020-04-20T09:02:02Z",
       }
     }
   },
@@ -43,19 +43,19 @@ it("unlinks all notes", () => {
 
   // Clipboard
   expect(unlinkedNotes.Clipboard.content).toBe("Clipboard content");
-  expect(unlinkedNotes.Clipboard.createdTime).toBe("2020-04-20T09:07:00.000Z");
-  expect(unlinkedNotes.Clipboard.modifiedTime).toBe("2020-04-20T09:07:07.000Z");
+  expect(unlinkedNotes.Clipboard.createdTime).toBe("2020-04-20T09:07:00Z");
+  expect(unlinkedNotes.Clipboard.modifiedTime).toBe("2020-04-20T09:07:07Z");
   expect("sync" in unlinkedNotes.Clipboard).toBe(false);
 
   // Radio
   expect(unlinkedNotes.Radio.content).toBe("some radio stations");
-  expect(unlinkedNotes.Radio.createdTime).toBe("2020-04-20T09:05:00.000Z");
-  expect(unlinkedNotes.Radio.modifiedTime).toBe("2020-04-20T09:05:05.000Z");
+  expect(unlinkedNotes.Radio.createdTime).toBe("2020-04-20T09:05:00Z");
+  expect(unlinkedNotes.Radio.modifiedTime).toBe("2020-04-20T09:05:05Z");
   expect("sync" in unlinkedNotes.Radio).toBe(false);
 
   // Todo
   expect(unlinkedNotes.Todo.content).toBe("buy milk, buy coffee");
-  expect(unlinkedNotes.Todo.createdTime).toBe("2020-04-20T09:02:00.000Z");
-  expect(unlinkedNotes.Todo.modifiedTime).toBe("2020-04-20T09:02:07.000Z");
+  expect(unlinkedNotes.Todo.createdTime).toBe("2020-04-20T09:02:00Z");
+  expect(unlinkedNotes.Todo.modifiedTime).toBe("2020-04-20T09:02:07Z");
   expect("sync" in unlinkedNotes.Todo).toBe(false);
 });

--- a/src/background/google-drive/sync/pull/__tests__/pull-create.test.ts
+++ b/src/background/google-drive/sync/pull/__tests__/pull-create.test.ts
@@ -58,7 +58,7 @@ const files: GoogleDriveFile[] = [
 
 const getFile: GetFileFunction = (fileId: string) => Promise.resolve(`content from ${fileId}`);
 
-test("pullCreate() creates notes for every new file where note with file's name doest NOT exist (no conflict)", async () => {
+test("pullCreate() creates notes for every file where note with file's name does NOT exist and file is NOT synced to any existing note", async () => {
   const notesAfterPullCreate = await pullCreate(notes, files, getFile);
   expect(notesAfterPullCreate).toEqual({
     // "Books" should be downloaded (file is new, note did not exist)

--- a/src/background/google-drive/sync/pull/__tests__/pull-update.test.ts
+++ b/src/background/google-drive/sync/pull/__tests__/pull-update.test.ts
@@ -2,152 +2,380 @@ import { NotesObject, GoogleDriveFile } from "shared/storage/schema";
 import { GetFileFunction } from "background/google-drive/api";
 import { pullUpdate } from "../pull-update";
 
-const notes: NotesObject = {
-  Books: {
-    content: "my books",
-    createdTime: "2021-04-02T14:30:00Z",
-    modifiedTime: "2021-04-02T14:45:00Z",
-    sync: {
-      file: {
-        id: "FILE-BOOKS",
-        name: "Books",
-        createdTime: "2021-04-02T14:30:00Z",
-        modifiedTime: "2021-04-02T14:45:00Z",
-      }
-    },
-  },
-  Todo: {
-    content: "my todo",
-    createdTime: "2021-04-03T15:00:00Z",
-    modifiedTime: "2021-04-03T15:10:00Z",
-    sync: {
-      file: {
-        id: "FILE-TODO",
-        name: "Todo",
-        createdTime: "2021-04-03T15:00:00Z",
-        modifiedTime: "2021-04-03T15:10:00Z",
-      }
-    }
-  },
-  Amazon: {
-    content: "my amazon",
-    createdTime: "2021-04-04T10:00:00Z",
-    modifiedTime: "2021-04-04T10:30:00Z",
-    sync: {
-      file: {
-        id: "FILE-123",
-        name: "Amazon",
-        createdTime: "2021-04-04T10:00:00Z",
-        modifiedTime: "2021-04-04T10:30:00Z",
-      }
-    }
-  },
-  Music: {
-    content: "my music",
-    createdTime: "2021-04-07T10:00:00Z",
-    modifiedTime: "2021-04-07T10:52:00Z", // updated since the last sync
-    sync: {
-      file: {
-        id: "FILE-MUSIC",
-        name: "Music",
-        createdTime: "2021-04-07T10:00:00Z",
-        modifiedTime: "2021-04-07T10:45:00Z",
-      }
-    }
-  },
-  Cooking: {
-    content: "my cooking",
-    createdTime: "2021-04-08T06:30:00Z",
-    modifiedTime: "2021-04-08T13:05:00Z", // updated since the last sync
-    sync: {
-      file: {
-        id: "FILE-591",
-        name: "Cooking",
-        createdTime: "2021-04-08T06:30:00Z",
-        modifiedTime: "2021-04-08T06:50:00Z",
-      }
-    }
-  }
-};
-
-const files: GoogleDriveFile[] = [
-  {
-    id: "FILE-BOOKS",
-    name: "Books",
-    createdTime: "2021-04-02T14:30:00Z",
-    modifiedTime: "2021-04-02T14:45:00Z",
-  },
-  {
-    id: "FILE-TODO",
-    name: "Todo",
-    createdTime: "2021-04-03T15:00:00Z",
-    modifiedTime: "2021-04-08T08:30:00Z", // updated in Google Drive
-  },
-  {
-    id: "FILE-123",
-    name: "Gifts", // renamed in Google Drive
-    createdTime: "2021-04-04T10:00:00Z",
-    modifiedTime: "2021-04-07T19:00:00Z", // updated in Google Drive
-  },
-  {
-    id: "FILE-MUSIC",
-    name: "Music",
-    createdTime: "2021-04-07T10:00:00Z",
-    modifiedTime: "2021-04-07T14:30:00Z", // updated in Google Drive, but also locally after the last sync
-  },
-  {
-    id: "FILE-591",
-    name: "Recipes", // renamed in Google Drive
-    createdTime: "2021-04-08T06:30:00Z",
-    modifiedTime: "2021-04-08T09:25:00Z", // updated in Google Drive, but also locally after the last sync
-  },
-];
-
 const getFile: GetFileFunction = (fileId: string) => Promise.resolve(`content from ${fileId}`);
 
-test("pullUpdate() updates notes that had their files updated in Google Drive since the last sync", async () => {
-  const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
-  expect(notesAfterPullUpdate).toEqual({
-    Books: notes["Books"], // unchanged
-    Todo: {
-      content: "content from FILE-TODO",
-      createdTime: "2021-04-03T15:00:00Z",
-      modifiedTime: "2021-04-08T08:30:00Z",
-      sync: {
-        file: {
-          id: "FILE-TODO",
-          name: "Todo",
-          createdTime: "2021-04-03T15:00:00Z",
-          modifiedTime: "2021-04-08T08:30:00Z",
-        }
-      }
-    },
-    Gifts: {
-      content: "content from FILE-123",
-      createdTime: "2021-04-04T10:00:00Z",
-      modifiedTime: "2021-04-07T19:00:00Z",
-      sync: {
-        file: {
-          id: "FILE-123",
-          name: "Gifts",
-          createdTime: "2021-04-04T10:00:00Z",
-          modifiedTime: "2021-04-07T19:00:00Z",
-        }
-      }
-    },
-    Music: {
-      content: "my music<br><br>content from FILE-MUSIC", // content merged
-      createdTime: "2021-04-07T10:00:00Z",
-      modifiedTime: "2021-04-07T14:30:00Z",
-      sync: {
-        file: {
-          id: "FILE-MUSIC",
-          name: "Music",
-          createdTime: "2021-04-07T10:00:00Z",
-          modifiedTime: "2021-04-07T14:30:00Z", // remote update was the latest
-        }
-      }
-    },
-    Cooking: notes["Cooking"], // modified in Google Drive, but also locally and that was the latest update (candidate for push)
+describe("pullUpdate()", () => {
+  describe("note is synced", () => {
+    describe("note is NOT modified since the last sync", () => {
+      describe("file is NOT modified since the last sync", () => {
+        test("note remains unchanged", async () => {
+          const notes: NotesObject = {
+            Books: {
+              content: "my books",
+              createdTime: "CT",
+              modifiedTime: "MT",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Books",
+                  createdTime: "CT",
+                  modifiedTime: "MT",
+                }
+              }
+            }
+          };
+
+          const files: GoogleDriveFile[] = [
+            {
+              id: "FILE-123",
+              name: "Books",
+              createdTime: "CT",
+              modifiedTime: "MT",
+            }
+          ];
+
+          const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+          expect(notesAfterPullUpdate).toEqual(notes);
+        });
+      });
+
+      describe("file is modified since the last sync", () => {
+        test("note content is replaced with file content", async () => {
+          const notes: NotesObject = {
+            Books: {
+              content: "my books",
+              createdTime: "CT",
+              modifiedTime: "MT",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Books",
+                  createdTime: "CT",
+                  modifiedTime: "MT",
+                }
+              }
+            }
+          };
+
+          const files: GoogleDriveFile[] = [
+            {
+              id: "FILE-123",
+              name: "Books",
+              createdTime: "CT",
+              modifiedTime: "MT-2",
+            }
+          ];
+
+          const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+          expect(notesAfterPullUpdate).toEqual({
+            Books: {
+              content: "content from FILE-123",
+              createdTime: "CT",
+              modifiedTime: "MT-2",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Books",
+                  createdTime: "CT",
+                  modifiedTime: "MT-2",
+                }
+              }
+            }
+          });
+        });
+      });
+
+      describe("file is modified since the last sync, and renamed", () => {
+        test("note content is replaced with file content, and note is renamed", async () => {
+          const notes: NotesObject = {
+            Books: {
+              content: "my books",
+              createdTime: "CT",
+              modifiedTime: "MT",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Books",
+                  createdTime: "CT",
+                  modifiedTime: "MT",
+                }
+              }
+            }
+          };
+
+          const files: GoogleDriveFile[] = [
+            {
+              id: "FILE-123",
+              name: "Readings",
+              createdTime: "CT",
+              modifiedTime: "MT-2",
+            }
+          ];
+
+          const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+          expect(notesAfterPullUpdate).toEqual({
+            Readings: {
+              content: "content from FILE-123",
+              createdTime: "CT",
+              modifiedTime: "MT-2",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Readings",
+                  createdTime: "CT",
+                  modifiedTime: "MT-2",
+                }
+              }
+            }
+          });
+        });
+      });
+    });
+
+    describe("note is modified since the last sync", () => {
+      describe("file is modified since the last sync", () => {
+        describe("note is the latest update", () => {
+          test("note remains unchanged, it is candidate for push", async () => {
+            const notes: NotesObject = {
+              Books: {
+                content: "my books",
+                createdTime: "CT",
+                modifiedTime: "MT-3",
+                sync: {
+                  file: {
+                    id: "FILE-123",
+                    name: "Books",
+                    createdTime: "CT",
+                    modifiedTime: "MT",
+                  }
+                }
+              }
+            };
+
+            const files: GoogleDriveFile[] = [
+              {
+                id: "FILE-123",
+                name: "Books",
+                createdTime: "CT",
+                modifiedTime: "MT-2",
+              }
+            ];
+
+            const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+            expect(notesAfterPullUpdate).toEqual(notes);
+          });
+        });
+
+        describe("file is the latest update", () => {
+          test("note content is merged with file content, file's modified time is definitive", async () => {
+            const notes: NotesObject = {
+              Books: {
+                content: "my books",
+                createdTime: "CT",
+                modifiedTime: "MT-4",
+                sync: {
+                  file: {
+                    id: "FILE-123",
+                    name: "Books",
+                    createdTime: "CT",
+                    modifiedTime: "MT",
+                  }
+                }
+              }
+            };
+
+            const files: GoogleDriveFile[] = [
+              {
+                id: "FILE-123",
+                name: "Books",
+                createdTime: "CT",
+                modifiedTime: "MT-6",
+              }
+            ];
+
+            const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+            expect(notesAfterPullUpdate).toEqual({
+              Books: {
+                content: "my books<br><br>content from FILE-123",
+                createdTime: "CT",
+                modifiedTime: "MT-6",
+                sync: {
+                  file: {
+                    id: "FILE-123",
+                    name: "Books",
+                    createdTime: "CT",
+                    modifiedTime: "MT-6",
+                  }
+                }
+              }
+            });
+          });
+        });
+
+        describe("file is the latest update, and renamed", () => {
+          test("note content is merged with file content, file's modified time is definitive, and note is renamed", async () => {
+            const notes: NotesObject = {
+              Books: {
+                content: "my books",
+                createdTime: "CT",
+                modifiedTime: "MT-4",
+                sync: {
+                  file: {
+                    id: "FILE-123",
+                    name: "Books",
+                    createdTime: "CT",
+                    modifiedTime: "MT",
+                  }
+                }
+              }
+            };
+
+            const files: GoogleDriveFile[] = [
+              {
+                id: "FILE-123",
+                name: "Wishlist",
+                createdTime: "CT",
+                modifiedTime: "MT-7",
+              }
+            ];
+
+            const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+            expect(notesAfterPullUpdate).toEqual({
+              Wishlist: {
+                content: "my books<br><br>content from FILE-123",
+                createdTime: "CT",
+                modifiedTime: "MT-7",
+                sync: {
+                  file: {
+                    id: "FILE-123",
+                    name: "Wishlist",
+                    createdTime: "CT",
+                    modifiedTime: "MT-7",
+                  }
+                }
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe("note is NOT synced", () => {
+    describe("note and file have the same modified time", () => {
+      test("sync property is added, note content is unchanged", async () => {
+        const notes: NotesObject = {
+          Books: {
+            content: "my books",
+            createdTime: "CT",
+            modifiedTime: "MT",
+          }
+        };
+
+        const files: GoogleDriveFile[] = [
+          {
+            id: "FILE-123",
+            name: "Books",
+            createdTime: "CT",
+            modifiedTime: "MT",
+          }
+        ];
+
+        const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+        expect(notesAfterPullUpdate).toEqual({
+          Books: {
+            content: "my books",
+            createdTime: "CT",
+            modifiedTime: "MT",
+            sync: {
+              file: {
+                id: "FILE-123",
+                name: "Books",
+                createdTime: "CT",
+                modifiedTime: "MT",
+              }
+            }
+          }
+        });
+      });
+    });
+
+    describe("note and file do NOT have the same modified time", () => {
+      describe("note is newer", () => {
+        test("sync property is added, note content is merged with file content, file's modified time is definitive", async () => {
+          const notes: NotesObject = {
+            Books: {
+              content: "my books",
+              createdTime: "CT",
+              modifiedTime: "MT-2",
+            }
+          };
+
+          const files: GoogleDriveFile[] = [
+            {
+              id: "FILE-123",
+              name: "Books",
+              createdTime: "CT",
+              modifiedTime: "MT",
+            }
+          ];
+
+          const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+          expect(notesAfterPullUpdate).toEqual({
+            Books: {
+              content: "my books<br><br>content from FILE-123",
+              createdTime: "CT",
+              modifiedTime: "MT",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Books",
+                  createdTime: "CT",
+                  modifiedTime: "MT",
+                }
+              }
+            }
+          });
+        });
+      });
+
+      describe("file is newer", () => {
+        test("sync property is added, note content is merged with file content, file's modified time is definitive", async () => {
+          const notes: NotesObject = {
+            Books: {
+              content: "my books",
+              createdTime: "CT",
+              modifiedTime: "MT-2",
+            }
+          };
+
+          const files: GoogleDriveFile[] = [
+            {
+              id: "FILE-123",
+              name: "Books",
+              createdTime: "CT",
+              modifiedTime: "MT-3",
+            }
+          ];
+
+          const notesAfterPullUpdate = await pullUpdate(notes, files, getFile);
+          expect(notesAfterPullUpdate).toEqual({
+            Books: {
+              content: "my books<br><br>content from FILE-123",
+              createdTime: "CT",
+              modifiedTime: "MT-3",
+              sync: {
+                file: {
+                  id: "FILE-123",
+                  name: "Books",
+                  createdTime: "CT",
+                  modifiedTime: "MT-3",
+                }
+              }
+            }
+          });
+        });
+      });
+    });
   });
 });

--- a/src/background/google-drive/sync/pull/pull-create.ts
+++ b/src/background/google-drive/sync/pull/pull-create.ts
@@ -2,16 +2,16 @@ import { NotesObject, GoogleDriveFile } from "shared/storage/schema";
 import { Log } from "shared/logger";
 import { GetFileFunction } from "background/google-drive/api";
 
-const getFilesThatHaveNoNote = (notes: NotesObject, remoteFiles: GoogleDriveFile[]): GoogleDriveFile[] => {
+const getNewFiles = (notes: NotesObject, remoteFiles: GoogleDriveFile[]): GoogleDriveFile[] => {
   const existingNoteNames = Object.keys(notes);
   const syncedFileIds = Object.values(notes).map((note) => note.sync?.file.id);
 
   const newFiles = remoteFiles.filter((file) => {
-    const canCreateNote =
+    const isNewFile =
       !existingNoteNames.includes(file.name) // note with file's name does NOT exist (no conflict)
       && !syncedFileIds.includes(file.id); // file is NOT synced to any note
 
-    return canCreateNote;
+    return isNewFile;
   });
 
   return newFiles;
@@ -19,7 +19,7 @@ const getFilesThatHaveNoNote = (notes: NotesObject, remoteFiles: GoogleDriveFile
 
 export const pullCreate = async (notes: NotesObject, remoteFiles: GoogleDriveFile[], getFile: GetFileFunction): Promise<NotesObject> => {
   const notesCopy = Object.assign({}, notes);
-  const newFiles = getFilesThatHaveNoNote(notesCopy, remoteFiles);
+  const newFiles = getNewFiles(notesCopy, remoteFiles);
 
   for (const file of newFiles) {
     const fileContent = await getFile(file.id) || "";

--- a/src/background/google-drive/sync/pull/pull-delete.ts
+++ b/src/background/google-drive/sync/pull/pull-delete.ts
@@ -5,12 +5,12 @@ const getNoteNamesToDelete = (notes: NotesObject, remoteFiles: GoogleDriveFile[]
   const notesNamesToDelete = Object.keys(notes).filter(noteName => {
     const note = notes[noteName];
     const fileId = note.sync?.file.id;
-    const canDelete =
+    const canDeleteNote =
       note.sync?.file.id // note was before synced to a file in Google Drive
       && note.sync?.file.modifiedTime === note.modifiedTime // note was NOT modified since the last sync
       && remoteFiles.find(file => file.id === fileId) === undefined; // file in Google Drive is not found
 
-    return canDelete;
+    return canDeleteNote;
   });
 
   return notesNamesToDelete;

--- a/src/background/google-drive/sync/pull/pull-update.ts
+++ b/src/background/google-drive/sync/pull/pull-update.ts
@@ -1,49 +1,88 @@
-import { NotesObject, GoogleDriveFile } from "shared/storage/schema";
+import { NotesObject, Note, GoogleDriveFile } from "shared/storage/schema";
 import { Log } from "shared/logger";
 import { GetFileFunction } from "background/google-drive/api";
 
-const getFilesThatHaveBeenUpdated = (notes: NotesObject, remoteFiles: GoogleDriveFile[]): GoogleDriveFile[] => {
-  const updatedFiles = remoteFiles.filter(file => {
-    const syncedNote = Object.values(notes).find((note) => note.sync?.file.id === file.id);
-    if (!syncedNote) {
-      return false;
+const prepareNote = (content: string, file: GoogleDriveFile): Note => ({
+  content,
+  createdTime: file.createdTime,
+  modifiedTime: file.modifiedTime,
+  sync: {
+    file: {
+      id: file.id,
+      name: file.name,
+      createdTime: file.createdTime,
+      modifiedTime: file.modifiedTime,
     }
+  }
+});
 
-    const isFileUpdated = new Date(syncedNote.modifiedTime).getTime() < new Date(file.modifiedTime).getTime();
-    return isFileUpdated;
-  });
+const mergeContent = (noteContent: string, fileContent: string) => noteContent + "<br><br>" + fileContent;
 
-  return updatedFiles;
+const updateNote = async (
+  notes: NotesObject,
+  syncedNote: Note,
+  file: GoogleDriveFile,
+  getFile: GetFileFunction,
+  contentResolution: "replace" | "merge"
+) => {
+  const notesCopy: NotesObject = { ...notes };
+
+  const previousNoteName = Object.keys(notesCopy).find((key) => notesCopy[key] === syncedNote);
+  const fileContent = await getFile(file.id) || "";
+
+  Log(`SYNC - IN - UPDATING NOTE - ${file.name} (name before: ${previousNoteName || file.name}, modified local, remote: ${syncedNote.modifiedTime}, ${file.modifiedTime})`, "blue");
+  notesCopy[file.name] = prepareNote(
+    contentResolution === "replace" ? fileContent : mergeContent(syncedNote.content, fileContent),
+    file,
+  );
+
+  if (previousNoteName && previousNoteName !== file.name) {
+    delete notesCopy[previousNoteName];
+  }
+
+  return notesCopy;
 };
 
 export const pullUpdate = async (notes: NotesObject, remoteFiles: GoogleDriveFile[], getFile: GetFileFunction): Promise<NotesObject> => {
-  const notesCopy = { ...notes };
-  const updatedFiles = getFilesThatHaveBeenUpdated(notesCopy, remoteFiles);
+  let notesCopy: NotesObject = { ...notes };
 
-  for (const file of updatedFiles) {
-    const note = Object.values(notesCopy).find((note) => note.sync?.file.id === file.id);
-    const previousNoteName = Object.keys(notesCopy).find((key) => notesCopy[key] === note);
+  for (const file of remoteFiles) {
+    const syncedNote = Object.values(notes).find((note) => note.sync?.file.id === file.id);
 
-    if (!note || !previousNoteName) {
-      continue;
+    if (
+      syncedNote && syncedNote.sync // note is synced
+      && syncedNote.modifiedTime === syncedNote.sync.file.modifiedTime // note is NOT modified since the last sync
+      && file.modifiedTime > syncedNote.modifiedTime // file is modified since the last sync
+    ) {
+      notesCopy = await updateNote(notesCopy, syncedNote, file, getFile, "replace");
     }
 
-    const fileContent = await getFile(file.id) || "";
-    const newNoteContent = note.modifiedTime === note.sync?.file.modifiedTime
-      ? fileContent
-      : note.content + "<br><br>" + fileContent; // note was modified since last sync, merge content
+    if (
+      syncedNote && syncedNote.sync // note is synced
+      && syncedNote.modifiedTime !== syncedNote.sync.file.modifiedTime // note is modified since the last sync
+      && file.modifiedTime > syncedNote.modifiedTime // file is modified since the last sync, file is the latest update
+    ) {
+      notesCopy = await updateNote(notesCopy, syncedNote, file, getFile, "merge");
+    }
 
-    Log(`SYNC - IN - UPDATING NOTE - ${file.name} (name before: ${previousNoteName}, modified local/remote: ${note.modifiedTime}/${file.modifiedTime})`, "blue");
+    if (
+      !syncedNote && file.name in notesCopy // note is NOT synced
+      && notesCopy[file.name].modifiedTime === file.modifiedTime // note and file have the same modified time
+    ) {
+      Log(`SYNC - IN - UPDATING NOTE - ${file.name} (name before: ${file.name}, modified local, remote: ${notesCopy[file.name].modifiedTime}, ${file.modifiedTime})`, "blue");
+      notesCopy[file.name] = prepareNote(notesCopy[file.name].content, file);
+    }
 
-    notesCopy[file.name] = {
-      content: newNoteContent,
-      createdTime: file.createdTime,
-      modifiedTime: file.modifiedTime,
-      sync: { file },
-    };
-
-    if (file.name !== previousNoteName) {
-      delete notesCopy[previousNoteName];
+    if (
+      !syncedNote && file.name in notesCopy // note is NOT synced
+      && notesCopy[file.name].modifiedTime !== file.modifiedTime // note and file do NOT have the same modified time
+    ) {
+      const fileContent = await getFile(file.id) || "";
+      Log(`SYNC - IN - UPDATING NOTE - ${file.name} (name before: ${file.name}, modified local, remote: ${notesCopy[file.name].modifiedTime}, ${file.modifiedTime})`, "blue");
+      notesCopy[file.name] = prepareNote(
+        mergeContent(notesCopy[file.name].content, fileContent),
+        file,
+      );
     }
   }
 

--- a/src/background/google-drive/sync/push.ts
+++ b/src/background/google-drive/sync/push.ts
@@ -32,7 +32,7 @@ export default async (folderId: string, notes: NotesObject, { createFile, update
 
     // 2. Update file for every updated note
     //    COND: note.modifiedTime > note.sync.file.modifiedTime
-    if (new Date(note.modifiedTime).getTime() > new Date(note.sync.file.modifiedTime).getTime()) {
+    if (note.modifiedTime > note.sync.file.modifiedTime) {
       Log(`SYNC - OUT - UPDATING FILE - ${noteName} (name before: ${note.sync.file.name})`);
       const file = await updateFile(note.sync.file.id, { ...note, name: noteName }); // Returns { id, name, content, modifiedTime }
       note.sync = { file: merge(note, file) };

--- a/src/background/init/migrations/__tests__/core-custom-values.test.ts
+++ b/src/background/init/migrations/__tests__/core-custom-values.test.ts
@@ -16,34 +16,34 @@ it("sets custom values", () => {
     notes: {
       Todo: {
         content: "buy milk",
-        createdTime: "2020-04-20T09:02:00.000Z",
-        modifiedTime: "2020-04-20T09:02:02.000Z",
+        createdTime: "2020-04-20T09:02:00Z",
+        modifiedTime: "2020-04-20T09:02:02Z",
         sync: {
           file: {
             id: "6073",
             name: "Todo",
-            createdTime: "2020-04-20T09:02:00.000Z",
-            modifiedTime: "2020-04-20T09:02:02.000Z",
+            createdTime: "2020-04-20T09:02:00Z",
+            modifiedTime: "2020-04-20T09:02:02Z",
           }
         }
       },
       Notebook: {
         content: "Notebook content",
-        createdTime: "2020-04-20T09:07:00.000Z",
-        modifiedTime: "2020-04-20T09:07:07.000Z",
+        createdTime: "2020-04-20T09:07:00Z",
+        modifiedTime: "2020-04-20T09:07:07Z",
         sync: {
           file: {
             id: "2931",
             name: "Notebook",
-            createdTime: "2020-04-20T09:07:00.000Z",
-            modifiedTime: "2020-04-20T09:07:07.000Z",
+            createdTime: "2020-04-20T09:07:00Z",
+            modifiedTime: "2020-04-20T09:07:07Z",
           }
         }
       },
       Math: {
         content: "some equations",
-        createdTime: "2020-04-20T09:09:00.000Z",
-        modifiedTime: "2020-04-20T09:09:09.000Z",
+        createdTime: "2020-04-20T09:09:00Z",
+        modifiedTime: "2020-04-20T09:09:09Z",
       },
     },
     active: "Todo",

--- a/src/background/init/migrations/__tests__/core-default-values.test.ts
+++ b/src/background/init/migrations/__tests__/core-default-values.test.ts
@@ -88,34 +88,34 @@ it("fallbacks active and clipboard if possible", () => {
     notes: {
       Todo: {
         content: "buy milk",
-        createdTime: "2020-04-20T09:02:00.000Z",
-        modifiedTime: "2020-04-20T09:02:02.000Z",
+        createdTime: "2020-04-20T09:02:00Z",
+        modifiedTime: "2020-04-20T09:02:02Z",
         sync: {
           file: {
             id: "6073",
             name: "Todo",
-            createdTime: "2020-04-20T09:02:00.000Z",
-            modifiedTime: "2020-04-20T09:02:02.000Z",
+            createdTime: "2020-04-20T09:02:00Z",
+            modifiedTime: "2020-04-20T09:02:02Z",
           }
         }
       },
       Clipboard: {
         content: "Clipboard content",
-        createdTime: "2020-04-20T09:07:00.000Z",
-        modifiedTime: "2020-04-20T09:07:07.000Z",
+        createdTime: "2020-04-20T09:07:00Z",
+        modifiedTime: "2020-04-20T09:07:07Z",
         sync: {
           file: {
             id: "2931",
             name: "Clipboard",
-            createdTime: "2020-04-20T09:07:00.000Z",
-            modifiedTime: "2020-04-20T09:07:07.000Z",
+            createdTime: "2020-04-20T09:07:00Z",
+            modifiedTime: "2020-04-20T09:07:07Z",
           }
         }
       },
       Math: {
         content: "some equations",
-        createdTime: "2020-04-20T09:09:00.000Z",
-        modifiedTime: "2020-04-20T09:09:09.000Z",
+        createdTime: "2020-04-20T09:09:00Z",
+        modifiedTime: "2020-04-20T09:09:09Z",
       },
     } as NotesObject
   };

--- a/src/background/init/migrations/__tests__/core-migration.test.ts
+++ b/src/background/init/migrations/__tests__/core-migration.test.ts
@@ -43,34 +43,34 @@ it("migrates data", () => {
     notes: {
       Todo: {
         content: "buy milk",
-        createdTime: "2020-04-20T09:02:00.000Z",
-        modifiedTime: "2020-04-20T09:02:02.000Z",
+        createdTime: "2020-04-20T09:02:00Z",
+        modifiedTime: "2020-04-20T09:02:02Z",
         sync: {
           file: {
             id: "6073",
             name: "Todo",
-            createdTime: "2020-04-20T09:02:00.000Z",
-            modifiedTime: "2020-04-20T09:02:02.000Z",
+            createdTime: "2020-04-20T09:02:00Z",
+            modifiedTime: "2020-04-20T09:02:02Z",
           }
         }
       },
       Clipboard: {
         content: "Clipboard content",
-        createdTime: "2020-04-20T09:07:00.000Z",
-        modifiedTime: "2020-04-20T09:07:07.000Z",
+        createdTime: "2020-04-20T09:07:00Z",
+        modifiedTime: "2020-04-20T09:07:07Z",
         sync: {
           file: {
             id: "2931",
             name: "Clipboard",
-            createdTime: "2020-04-20T09:07:00.000Z",
-            modifiedTime: "2020-04-20T09:07:07.000Z",
+            createdTime: "2020-04-20T09:07:00Z",
+            modifiedTime: "2020-04-20T09:07:07Z",
           }
         }
       },
       Math: {
         content: "some equations",
-        createdTime: "2020-04-20T09:09:00.000Z",
-        modifiedTime: "2020-04-20T09:09:09.000Z",
+        createdTime: "2020-04-20T09:09:00Z",
+        modifiedTime: "2020-04-20T09:09:09Z",
       },
     }
   };

--- a/src/shared/storage/index.ts
+++ b/src/shared/storage/index.ts
@@ -14,6 +14,14 @@ export const setItem = <T>(key: string, value: T): Promise<void> => {
   });
 };
 
+export const setItems = (items: Record<string, unknown>): Promise<void> => {
+  return new Promise(resolve => {
+    chrome.storage.local.set(items, () => {
+      resolve();
+    });
+  });
+};
+
 export const removeItem = (key: string): Promise<void> => {
   return new Promise(resolve => {
     chrome.storage.local.remove(key, () => {


### PR DESCRIPTION
Sync Pull Update was not able to connect note to an existing file and this resulted in creating a new file in Google Drive. I know this problem wasn't happening in first version, but there was some rewriting since.

As a solution I have rewritten Sync Pull Update and added additional tests to all sorts of scenarios I could think of:

```
pullUpdate()
  note is synced
    note is NOT modified since the last sync
      file is NOT modified since the last sync
        ✓ note remains unchanged (3 ms)
      file is modified since the last sync
        ✓ note content is replaced with file content (1 ms)
      file is modified since the last sync, and renamed
        ✓ note content is replaced with file content, and note is renamed
    note is modified since the last sync
      file is modified since the last sync
        note is the latest update
          ✓ note remains unchanged, it is candidate for push (1 ms)
        file is the latest update
          ✓ note content is merged with file content, file's modified time is definitive
        file is the latest update, and renamed
          ✓ note content is merged with file content, file's modified time is definitive, and note is renamed (1 ms)
  note is NOT synced
    note and file have the same modified time
      ✓ sync property is added, note content is unchanged
    note and file do NOT have the same modified time
      note is newer
        ✓ sync property is added, note content is merged with file content, file's modified time is definitive (1 ms)
      file is newer
        ✓ sync property is added, note content is merged with file content, file's modified time is definitive
```

Closes https://github.com/penge/my-notes/issues/254.

Additionally I have fixed that note is now auto-refreshed if it is open and updated with a file's content after the sync.

I have as well added a function to react to any removed permissions on start which could happen if extension was restarted repeatedly. This is more of a edge case which I found during the testing.

Last but not least, I have made a small fix that makes sure assets folder ID is not unset after the sync, rather its previous value is kept.