### PR TITLE
Define type Os

### DIFF
--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -1,7 +1,8 @@
-import { h, render, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, render, Fragment } from "preact";
 import { useState, useEffect, useRef, useCallback } from "preact/hooks";
 
 import {
+  Os,
   Storage,
   Notification,
   RegularFont,
@@ -44,8 +45,8 @@ interface NotesProps {
   active: string
 }
 
-const Notes = () => {
-  const [os, setOs] = useState<"mac" | "other" | undefined>(undefined);
+const Notes = (): h.JSX.Element => {
+  const [os, setOs] = useState<Os | undefined>(undefined);
   const [tabId, setTabId] = useState<string>("");
 
   const [notification, setNotification] = useState<Notification | undefined>(undefined);

--- a/src/notes/components/Sidebar.tsx
+++ b/src/notes/components/Sidebar.tsx
@@ -1,7 +1,7 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, Fragment } from "preact";
 import { useRef, useCallback, useEffect, useState } from "preact/hooks";
 import clsx from "clsx";
-import { NotesObject, Sync, MessageType } from "shared/storage/schema";
+import { Os, NotesObject, Sync, MessageType } from "shared/storage/schema";
 import Drag from "./Drag";
 import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
 import formatDate from "shared/date/format-date";
@@ -30,7 +30,7 @@ const syncNowTitles = {
 };
 
 interface SidebarProps {
-  os?: "mac" | "other"
+  os?: Os
   notes: NotesObject
   active: string
   width?: string

--- a/src/notes/components/Toolbar.tsx
+++ b/src/notes/components/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, Fragment } from "preact";
 import { useCallback, useEffect, useState } from "preact/hooks";
 import clsx from "clsx";
 import commands from "../toolbar/commands";
@@ -6,7 +6,7 @@ import InsertImageModal, { InsertImageModalProps } from "./modals/InsertImageMod
 import InsertLinkModal, { InsertLinkModalProps } from "./modals/InsertLinkModal";
 import range from "../range";
 import Tooltip from "./Tooltip";
-import { Note, Theme } from "shared/storage/schema";
+import { Os, Note } from "shared/storage/schema";
 import NoteInfo from "./NoteInfo";
 import { capitalize } from "shared/string/capitalize-string";
 import { HIGHLIGHT_COLORS } from "notes/toolbar/highlight";
@@ -79,9 +79,8 @@ const titles = {
 } as { [key in Title]: { mac: string, other: string } };
 
 interface ToolbarProps {
-  os?: "mac" | "other"
+  os?: Os
   note?: Note
-  theme?: Theme
 }
 
 const Toolbar = ({ os, note }: ToolbarProps): h.JSX.Element => {

--- a/src/notes/keyboard-shortcuts.ts
+++ b/src/notes/keyboard-shortcuts.ts
@@ -1,4 +1,6 @@
-const isMac = (os: string) => os === "mac";
+import { Os } from "shared/storage/schema";
+
+const isMac = (os: Os) => os === "mac";
 
 export enum KeyboardShortcut {
   // Options
@@ -52,7 +54,7 @@ const publish = (keyboardShortcut: KeyboardShortcut, event: KeyboardEvent): void
   callbacks.forEach((callback) => callback());
 };
 
-const registerOpenOptions = (event: KeyboardEvent, os: string) => {
+const registerOpenOptions = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && event.code === "KeyO") ||
     (!isMac(os) && event.ctrlKey && event.shiftKey && event.code === "KeyO")
@@ -61,7 +63,7 @@ const registerOpenOptions = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerToggleFocusMode = (event: KeyboardEvent, os: string) => {
+const registerToggleFocusMode = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && event.code === "KeyF") ||
     (!isMac(os) && event.ctrlKey && event.shiftKey && event.code === "KeyF")
@@ -70,7 +72,7 @@ const registerToggleFocusMode = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerToggleSidebar = (event: KeyboardEvent, os: string) => {
+const registerToggleSidebar = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && !event.shiftKey && event.code === "KeyS") ||
     (!isMac(os) && event.ctrlKey && !event.shiftKey && event.code === "KeyS")
@@ -79,7 +81,7 @@ const registerToggleSidebar = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerToggleToolbar = (event: KeyboardEvent, os: string) => {
+const registerToggleToolbar = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.code === "KeyE") ||
     (!isMac(os) && event.ctrlKey && event.code === "KeyE")
@@ -88,7 +90,7 @@ const registerToggleToolbar = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerControl = (event: KeyboardEvent, os: string) => {
+const registerControl = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey) ||
     (!isMac(os) && event.ctrlKey)
@@ -115,13 +117,13 @@ const registerTab = (event: KeyboardEvent) => {
   }
 };
 
-const registerUnderline = (event: KeyboardEvent, os: string) => {
+const registerUnderline = (event: KeyboardEvent, os: Os) => {
   if (isMac(os) && event.metaKey && event.code === "KeyU") {
     publish(KeyboardShortcut.OnUnderline, event);
   }
 };
 
-const registerStrikethrough = (event: KeyboardEvent, os: string) => {
+const registerStrikethrough = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && event.code === "KeyX") ||
     (!isMac(os) && event.altKey && event.shiftKey && event.code === "Digit5")
@@ -130,7 +132,7 @@ const registerStrikethrough = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerRemoveFormat = (event: KeyboardEvent, os: string) => {
+const registerRemoveFormat = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.code === "Backslash") ||
     (!isMac(os) && event.ctrlKey && event.code === "Backslash")
@@ -139,7 +141,7 @@ const registerRemoveFormat = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerUnorderedList = (event: KeyboardEvent, os: string) => {
+const registerUnorderedList = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && event.code === "Digit7") ||
     (!isMac(os) && event.ctrlKey && event.shiftKey && event.code === "Digit7")
@@ -148,7 +150,7 @@ const registerUnorderedList = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerOrderedList = (event: KeyboardEvent, os: string) => {
+const registerOrderedList = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && event.code === "Digit8") ||
     (!isMac(os) && event.ctrlKey && event.shiftKey && event.code === "Digit8")
@@ -157,7 +159,7 @@ const registerOrderedList = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerInsertDate = (event: KeyboardEvent, os: string) => {
+const registerInsertDate = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && !event.shiftKey && !event.altKey && event.code === "Semicolon") ||
     (!isMac(os) && event.ctrlKey && !event.shiftKey && !event.altKey && event.code === "Semicolon")
@@ -166,7 +168,7 @@ const registerInsertDate = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerInsertTime = (event: KeyboardEvent, os: string) => {
+const registerInsertTime = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && !event.altKey && event.code === "Semicolon") ||
     (!isMac(os) && event.ctrlKey && event.shiftKey && !event.altKey && event.code === "Semicolon")
@@ -175,7 +177,7 @@ const registerInsertTime = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerInsertDateAndTime = (event: KeyboardEvent, os: string) => {
+const registerInsertDateAndTime = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.shiftKey && event.altKey && event.code === "Semicolon") ||
     (!isMac(os) && event.ctrlKey && event.shiftKey && event.altKey && event.code === "Semicolon")
@@ -184,7 +186,7 @@ const registerInsertDateAndTime = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const registerSyncNotes = (event: KeyboardEvent, os: string) => {
+const registerSyncNotes = (event: KeyboardEvent, os: Os) => {
   if (
     (isMac(os) && event.metaKey && event.code === "KeyR") ||
     (!isMac(os) && event.ctrlKey && event.code === "KeyR")
@@ -193,7 +195,7 @@ const registerSyncNotes = (event: KeyboardEvent, os: string) => {
   }
 };
 
-const keydown = (os: string) => document.addEventListener("keydown", (event) => {
+const keydown = (os: Os) => document.addEventListener("keydown", (event) => {
   // Options
   registerOpenOptions(event, os);
 
@@ -230,7 +232,7 @@ const keyup = () => document.addEventListener("keyup", () => {
   document.body.classList.remove("with-control");
 });
 
-const register = (os: "mac" | "other"): void => {
+const register = (os: Os): void => {
   keydown(os);
   keyup();
 };

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,4 +1,4 @@
-import { h, render, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, render, Fragment } from "preact";
 import { useState, useEffect } from "preact/hooks";
 
 import __Font from "options/Font";
@@ -9,6 +9,7 @@ import __Options from "options/Options";
 import __Version from "options/Version";
 
 import {
+  Os,
   Storage,
   RegularFont,
   GoogleFont,
@@ -17,7 +18,8 @@ import {
 } from "shared/storage/schema";
 import { setTheme as setThemeCore } from "themes/set-theme";
 
-const Options = () => {
+const Options = (): h.JSX.Element => {
+  const [os, setOs] = useState<Os | undefined>(undefined);
   const [version] = useState<string>(chrome.runtime.getManifest().version);
   const [font, setFont] = useState<RegularFont | GoogleFont | undefined>(undefined);
   const [size, setSize] = useState<number>(0);
@@ -29,6 +31,8 @@ const Options = () => {
   const [tabSize, setTabSize] = useState<number>(-1);
 
   useEffect(() => {
+    chrome.runtime.getPlatformInfo((platformInfo) => setOs(platformInfo.os === "mac" ? "mac" : "other"));
+
     chrome.storage.local.get([
       "font",
       "size",
@@ -105,7 +109,7 @@ const Options = () => {
       <__Font font={font} />
       <__Size size={size} />
       <__Theme theme={theme} />
-      <__KeyboardShortcuts />
+      {os && <__KeyboardShortcuts os={os} />}
       <__Options
         sync={sync}
         autoSync={autoSync}

--- a/src/options/KeyboardShortcuts.tsx
+++ b/src/options/KeyboardShortcuts.tsx
@@ -1,36 +1,29 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { useState, useEffect } from "preact/hooks";
+import { h, Fragment } from "preact";
+import { Os } from "shared/storage/schema";
 import keyboardShortcuts from "./helpers/keyboard-shortcuts";
 
-const KeyboardShortcuts = (): h.JSX.Element => {
-  const [os, setOs] = useState<string>("");
+interface KeyboardShortcutsProps {
+  os: Os
+}
 
-  useEffect(() => {
-    chrome.runtime.getPlatformInfo((platformInfo) => {
-      const os = platformInfo.os === "mac" ? "mac" : "other";
-      setOs(os);
-    });
-  }, []);
-
-  return (
-    <Fragment>
-      <h2>Shortcuts</h2>
-      <table id="keyboard-shortcuts">
-        {keyboardShortcuts.map((shortcut) =>
-          <tr>
-            <td class="description">{shortcut.description}</td>
-            <td>
-              {shortcut.configurable && <span>e.g.&nbsp;</span>}
-              {shortcut.hold && <span>hold&nbsp;</span>}
-              {os === "mac" && <span class="keyboard-shortcut os-mac">{shortcut.mac}</span>}
-              {os === "other" && <span class="keyboard-shortcut os-other">{shortcut.other}</span>}
-              {shortcut.configurable && <span>&nbsp;(open <span class="url">chrome://extensions/shortcuts</span> to configure)</span>}
-            </td>
-          </tr>
-        )}
-      </table>
-    </Fragment>
-  );
-};
+const KeyboardShortcuts = ({ os }: KeyboardShortcutsProps): h.JSX.Element => (
+  <Fragment>
+    <h2>Shortcuts</h2>
+    <table id="keyboard-shortcuts">
+      {keyboardShortcuts.map((shortcut) =>
+        <tr>
+          <td class="description">{shortcut.description}</td>
+          <td>
+            {shortcut.configurable && <span>e.g.&nbsp;</span>}
+            {shortcut.hold && <span>hold&nbsp;</span>}
+            {os === "mac" && <span class="keyboard-shortcut os-mac">{shortcut.mac}</span>}
+            {os === "other" && <span class="keyboard-shortcut os-other">{shortcut.other}</span>}
+            {shortcut.configurable && <span>&nbsp;(open <span class="url">chrome://extensions/shortcuts</span> to configure)</span>}
+          </td>
+        </tr>
+      )}
+    </table>
+  </Fragment>
+);
 
 export default KeyboardShortcuts;

--- a/src/shared/storage/schema.ts
+++ b/src/shared/storage/schema.ts
@@ -1,3 +1,5 @@
+export type Os = "mac" | "other";
+
 export interface Note {
   content: string
   createdTime: string


### PR DESCRIPTION
My Notes sets keyboard shortcuts based on the OS, which can be:

- `mac`
- `other` (Windows, Linux, Chrome OS)

The reason for this is, Macs have a slightly different keyboard with `⌘` and `⌥` keys. Thus, it is better to handle the keyboard shortcuts **<ins>specifically</ins>** for different OS/keyboard to provide a **<ins>better experience</ins>** for that particular OS, and to prevent accidental keyboard shortcut override on that OS (some keyboard shortcut could be available on Windows but not on Mac and thus it would be overridden there, and vice versa).

The above is something we already have and I just wanted to cover the background first. Here's what this PR is about. I found OS options (`mac` and `other`) as very important (used at several places), and therefore, **<ins>it deserves its own type</ins>**, to have it at one place, defined once; to prevent any possible mistakes in this regard (it has to be `mac` or `other` but nothing else); as well to have a documentation purpose.
