### PR TITLE
Disable autocomplete in Modal

### DIFF
--- a/src/notes/components/modals/Modal.tsx
+++ b/src/notes/components/modals/Modal.tsx
@@ -66,6 +66,7 @@ const Modal = ({
           id="input"
           ref={inputRef}
           onBlur={() => inputRef.current?.focus()}
+          autocomplete="off"
         />
       )}
 


### PR DESCRIPTION
A tiny change that disables autocomplete in modals: New note, Rename note, Insert image, Insert link.

**Reason:** Although autocomplete can be useful in forms so we don't have to type in our email every time, there is no such or similar use-case in our application. Actually, having autocomplete is disturbing, as in all of our cases we are always working with something new and don't want to see what the previous values were (previously set note name, previously inserted image, previously inserted link).