### PR TITLE
Add host permission for `drive.google.com`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,9 @@
     "identity",
     "alarms"
   ],
+  "host_permissions": [
+    "https://drive.google.com/"
+  ],
   "oauth2": {
     "client_id": "813847979218-unbbh8m0el8vjdi74rnqdarm1mhv3985.apps.googleusercontent.com",
     "scopes": [


### PR DESCRIPTION
Resolves **"Indicate whether to send a cookie in a cross-site request by specifying its SameSite attribute"** by adding `https://drive.google.com/` to host permissions.

Makes cross-origin requests (from `chrome-extension://` to `https://drive.google.com/`) with their cookies OK.

`https://drive.google.com/` is the place where we store and then retrieve our images from.