### PR TITLE
Remove no longer needed linter exceptions

### DIFF
--- a/src/notes/components/Content.tsx
+++ b/src/notes/components/Content.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import { useCallback, useEffect, useRef } from "preact/hooks";
 import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
 import commands from "../toolbar/commands";

--- a/src/notes/components/ContextMenu.tsx
+++ b/src/notes/components/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import { useState, useRef, useEffect } from "preact/hooks";
 
 export interface ContextMenuProps {

--- a/src/notes/components/Drag.tsx
+++ b/src/notes/components/Drag.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import { Ref, useCallback } from "preact/hooks";
 
 let m_pos: number;

--- a/src/notes/components/NoteInfo.tsx
+++ b/src/notes/components/NoteInfo.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import { Note } from "shared/storage/schema";
 import parseDate from "shared/date/parse-date";
 import formatNumber from "shared/number/format-number";

--- a/src/notes/components/Overlay.tsx
+++ b/src/notes/components/Overlay.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import { useEffect } from "preact/hooks";
 
 interface OverlayProps {

--- a/src/notes/components/Tooltip.tsx
+++ b/src/notes/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { h, render, cloneElement, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, render, cloneElement, Fragment } from "preact";
 import { useRef, useState, useEffect, useMemo, useCallback } from "preact/hooks";
 
 interface TooltipProps {

--- a/src/notes/components/modals/DeleteNoteModal.tsx
+++ b/src/notes/components/modals/DeleteNoteModal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import Modal from "./Modal";
 
 export interface DeleteNoteModalProps {

--- a/src/notes/components/modals/InsertImageModal.tsx
+++ b/src/notes/components/modals/InsertImageModal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import Modal from "./Modal";
 
 export interface InsertImageModalProps {

--- a/src/notes/components/modals/InsertLinkModal.tsx
+++ b/src/notes/components/modals/InsertLinkModal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import Modal from "./Modal";
 
 export interface InsertLinkModalProps {

--- a/src/notes/components/modals/Modal.tsx
+++ b/src/notes/components/modals/Modal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import { useRef, useEffect, useCallback } from "preact/hooks";
 import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
 

--- a/src/notes/components/modals/NewNoteModal.tsx
+++ b/src/notes/components/modals/NewNoteModal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import Modal from "./Modal";
 
 export interface NewNoteModalProps {

--- a/src/notes/components/modals/RenameNoteModal.tsx
+++ b/src/notes/components/modals/RenameNoteModal.tsx
@@ -1,4 +1,4 @@
-import { h } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h } from "preact";
 import Modal from "./Modal";
 
 export interface RenameNoteModalProps {

--- a/src/options/Font.tsx
+++ b/src/options/Font.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, Fragment } from "preact";
 import { useState, useEffect } from "preact/hooks";
 import clsx from "clsx";
 import { RegularFont, GoogleFont } from "shared/storage/schema";

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, Fragment } from "preact";
 import { useCallback } from "preact/hooks";
 import { Sync } from "shared/storage/schema";
 import formatDate from "shared/date/format-date";

--- a/src/options/Size.tsx
+++ b/src/options/Size.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, Fragment } from "preact";
 
 interface SizeProps {
   size?: number

--- a/src/options/Theme.tsx
+++ b/src/options/Theme.tsx
@@ -1,4 +1,4 @@
-import { h, Fragment } from "preact"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { h, Fragment } from "preact";
 import { Theme } from "shared/storage/schema";
 import { capitalize } from "shared/string/capitalize-string";
 


### PR DESCRIPTION
Since the transition to Typescript and making the return type for components explicit as `h.JSX.Element`, there is no longer need for some ESlint exceptions that were previously needed.