### PR TITLE
Fix Auto Sync note rollback

### DIFF
--- a/src/background/init/google-drive.ts
+++ b/src/background/init/google-drive.ts
@@ -51,20 +51,20 @@ const autoSyncOnAlarmListener = (alarm: chrome.alarms.Alarm) => {
 };
 
 const attachGoogleDriveAutoSyncAlarm = (): void => withGrantedPermission("alarms", async () => {
+  if (!chrome.alarms.onAlarm.hasListener(autoSyncOnAlarmListener)) {
+    chrome.alarms.onAlarm.addListener(autoSyncOnAlarmListener);
+  }
+
   const existingAlarm = await chrome.alarms.get(AUTO_SYNC_ALARM_NAME);
   if (existingAlarm) {
     return; // AUTO_SYNC_ALARM_NAME is already registered
   }
 
-  chrome.alarms.onAlarm.removeListener(autoSyncOnAlarmListener);
-  chrome.alarms.clear(AUTO_SYNC_ALARM_NAME, () => {
-    chrome.alarms.onAlarm.addListener(autoSyncOnAlarmListener);
-    chrome.alarms.create(AUTO_SYNC_ALARM_NAME, {
-      periodInMinutes: 0.1, // Every 6 seconds
-    });
-
-    Log(`${PREFIX} - ${AUTO_SYNC_ALARM_NAME} was registered`);
+  chrome.alarms.create(AUTO_SYNC_ALARM_NAME, {
+    periodInMinutes: 0.1, // Every 6 seconds
   });
+
+  Log(`${PREFIX} - ${AUTO_SYNC_ALARM_NAME} was registered`);
 });
 
 const detachGoogleDriveAutoSyncAlarm = (): void => withGrantedPermission("alarms", () => {

--- a/src/background/init/permissions.ts
+++ b/src/background/init/permissions.ts
@@ -36,7 +36,7 @@ const handlePermissions = (permissionHandlers: PermissionHandlers, permissions: 
 
 export const handleChangedPermissions = (): void => {
   optionalPermissions.forEach((optionalPermission) => {
-    havingPermission(optionalPermission).then((having) => !having && __handlers["identity"](having));
+    havingPermission(optionalPermission).then((having) => !having && __handlers[optionalPermission](having));
   });
 
   chrome.permissions.onAdded.addListener((permissions) => handlePermissions(__handlers, permissions, { having: true }));

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -275,7 +275,11 @@ const Notes = (): h.JSX.Element => {
             (newActive in newNotes) &&
             (newNotes[newActive].content !== oldNotes[newActive].content)
           ) {
-            setInitialContent(newNotes[newActive].content);
+            if (newNotes[newActive].modifiedTime > oldNotes[newActive].modifiedTime) {
+              setInitialContent(newNotes[newActive].content);
+            } else {
+              saveNote(newActive, oldNotes[newActive].content, tabId, notesRef.current);
+            }
           }
 
           if (!(newActive in oldNotes)) {


### PR DESCRIPTION
This fix will check if the active note was updated by the user (user is typing into the note) during the Auto Sync, and make sure what user typed into the active note during the Auto Sync, is saved as the latest note version. This prevents note rollback (going back to older note version - version before Auto Sync started) that was happening before.

I'd like to thank @skinnedpanda for pointing out this issue.
Closes https://github.com/penge/my-notes/issues/280.

Besides the above fix, there's an update that makes sure Auto Sync alarm listener is registered on start (in case it was freed from the memory when the service worker was unloaded).