### PR TITLE
Restore selection when Command palette is dismissed

### DIFF
--- a/src/background/init/google-drive.ts
+++ b/src/background/init/google-drive.ts
@@ -111,6 +111,7 @@ export const registerGoogleDriveAutoSync = (): void => {
     chrome.storage.local.get(otherKey, (local) => {
       if (!local[otherKey]) {
         detachGoogleDriveAutoSyncAlarm();
+        return;
       }
 
       // Both "sync" and "autoSync" are enabled, we can attach the alarm

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -412,7 +412,13 @@ const Notes = (): h.JSX.Element => {
     keyboardShortcuts.register(os);
     keyboardShortcuts.subscribe(KeyboardShortcut.OnEscape, () => {
       setContextMenuProps(null);
-      setCommandPaletteProps(null);
+      setCommandPaletteProps((prev) => {
+        if (prev) {
+          range.restore();
+        }
+
+        return null;
+      });
     });
     keyboardShortcuts.subscribe(KeyboardShortcut.OnOpenOptions, () => chrome.tabs.create({ url: "/options.html" }));
     keyboardShortcuts.subscribe(KeyboardShortcut.OnToggleFocusMode, () => {


### PR DESCRIPTION
Pressing the `Esc` key to dismiss (close) the Command palette will now restore the selected text (text selected before opening the Command palette):

https://user-images.githubusercontent.com/907255/127360986-bd4856fd-e596-4107-898b-16b3c8614a5e.mov

<br>

Other changes:

- Adding a missing `return` statement to `registerGoogleDriveAutoSync()`.