### PR TITLE
Add `unlimitedStorage` permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ My Notes has the permissions listed in `manifest.json`.
 **Required:**
 
 - `"storage"` — used to save your notes and options to Chrome Storage (locally in your Chrome)
+- `"unlimitedStorage"` — used to increase the default storage limit (which is 5MB)
 - `"contextMenus"` — used to create My Notes Context menu
 
 Required permissions are shown to the user before installing the extension, and are needed at all times to provide the basic functionality.

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
   "options_page": "options.html",
   "permissions": [
     "storage",
+    "unlimitedStorage",
     "contextMenus"
   ],
   "optional_permissions": [


### PR DESCRIPTION
The following improvement will allow you to store more than 5MB (the previous default limit) in notes (useful for images).

<br>

### Detail

If you use My Notes as a clipboard for your images and you copy/paste them into your note(s) from a local program (file explorer, Word, Pages, or else), these images will be inserted as Base64 string each.

Base64 string-encoded image is fully independent (does not need access to file explorer, Word, Pages, or to anywhere else from where the image was originally copied from; also, the image in note will exist even after it was deleted in file explorer).

As a result, images inserted as Base64 have the size of the original image and even a bit more (~137% size due to the encoding). This way, inserting few images (let's say 1MB each) can lead to reaching 5MB limit very quickly.

When 5MB would be reached, there's no more space to save things. The best solution is to simply allow more space.

And this is where the following improvement comes and adds a new permission called `unlimitedStorage`. With this permission, notes are allowed to take more space than 5MB. The permission is set as required, meaning it is enabled at all times.

When new My Notes version including this permission will be installed, you may see a one-time prompt (for your confirmation), or will need to enable the extension again. From that moment, all is set.

I'd like to thank @khoaDLuu for reporting issue (https://github.com/penge/my-notes/issues/303) which lead to this solution.