### PR TITLE
Fix link opening when they have other than TEXT_NODE child

### DIFF
--- a/static/notes.css
+++ b/static/notes.css
@@ -289,6 +289,10 @@ body.with-control #content a {
   cursor: pointer;
 }
 
+body.with-control #content a > * {
+  pointer-events: none;
+}
+
 /* My Notes classes */
 
 .my-notes-highlight {


### PR DESCRIPTION
Fixes https://github.com/penge/my-notes/issues/308.

It was not possible to open a link if it was **Bold**, _Italic_, or ~~Strikethrough~~.