### PR TITLE
Resizable table columns and rows

### DIFF
--- a/src/notes/commands/table.ts
+++ b/src/notes/commands/table.ts
@@ -12,7 +12,7 @@ const withClosest = <T>(nodeName: string, fn: (el: T) => void) => withRange((ran
   }
 });
 
-const withtd = (fn: (tr: HTMLTableDataCellElement) => void) => withClosest<HTMLTableDataCellElement>("TD", fn);
+const withtd = (fn: (tr: HTMLTableCellElement) => void) => withClosest<HTMLTableCellElement>("TD", fn);
 const withtr = (fn: (tr: HTMLTableRowElement) => void) => withClosest<HTMLTableRowElement>("TR", fn);
 
 const insertRow = (table: HTMLTableElement, rowIndex: number, cellCount: number) => {
@@ -46,7 +46,7 @@ const insertRowRelative = (delta: number, cb: Callback) => withtr((tr: HTMLTable
 const insertRowAbove = (cb: Callback): void => insertRowRelative(0, cb);
 const insertRowBelow = (cb: Callback): void => insertRowRelative(1, cb);
 
-const insertColumnRelative = (delta: number, cb: Callback) => withtd((td: HTMLTableDataCellElement) => {
+const insertColumnRelative = (delta: number, cb: Callback) => withtd((td: HTMLTableCellElement) => {
   const table = td.closest("table") as HTMLTableElement;
   const index = td.cellIndex + delta;
   for (let row = 0; row < table.rows.length; row += 1) {
@@ -59,7 +59,7 @@ const insertColumnRelative = (delta: number, cb: Callback) => withtd((td: HTMLTa
 const insertColumnLeft = (cb: Callback): void => insertColumnRelative(0, cb);
 const insertColumnRight = (cb: Callback): void => insertColumnRelative(1, cb);
 
-const toggleHeadingRow = (cb: Callback): void => withtd((td: HTMLTableDataCellElement) => {
+const toggleHeadingRow = (cb: Callback): void => withtd((td: HTMLTableCellElement) => {
   const containsHeading = td.classList.contains("heading");
 
   const tr = td.closest("tr") as HTMLTableRowElement;
@@ -99,7 +99,7 @@ const deleteRow = (cb: Callback): void => withtr((tr: HTMLTableRowElement) => {
   cb();
 });
 
-const deleteColumn = (cb: Callback): void => withtd((td: HTMLTableDataCellElement) => {
+const deleteColumn = (cb: Callback): void => withtd((td: HTMLTableCellElement) => {
   const table = td.closest("table") as HTMLTableElement;
   const cellIndex = td.cellIndex;
   for (let row = 0; row < table.rows.length; row += 1) {

--- a/src/notes/components/Content.tsx
+++ b/src/notes/components/Content.tsx
@@ -7,6 +7,7 @@ import __range from "notes/range";
 import { isImageFile } from "./image/read-image";
 import { dropImage } from "./image/drop-image";
 import { runUploadPreconditions } from "background/google-drive/preconditions/upload-preconditions";
+import { reinitTables } from "notes/content/table";
 
 interface ContentProps {
   active: string
@@ -76,6 +77,12 @@ const Content = ({ active, locked, initialContent, onEdit, indentOnTab, tabSize 
     if (contentRef.current) {
       contentRef.current.innerHTML = initialContent;
       autofocus(contentRef.current);
+      reinitTables({
+        onResize: () => {
+          const event = new Event("editnote");
+          document.dispatchEvent(event);
+        }
+      });
     }
   }, [active, initialContent]);
 

--- a/src/notes/components/Toolbar.tsx
+++ b/src/notes/components/Toolbar.tsx
@@ -46,10 +46,18 @@ import TextColorSvgText from "svg/text-color.svg";
 import RemoveFormatSvgText from "svg/remove-format.svg";
 import InfoSvgText from "svg/info.svg";
 import SVG from "types/SVG";
+import { reinitTables } from "notes/content/table";
 
 const callback = () => {
   const event = new Event("editnote");
   document.dispatchEvent(event);
+};
+
+const tableCallback = () => {
+  callback();
+  reinitTables({
+    onResize: callback,
+  });
 };
 
 interface ToolbarProps {
@@ -109,27 +117,27 @@ const Toolbar = ({ os, note }: ToolbarProps): h.JSX.Element => {
         {submenu === "TABLE" && (
           <div class="submenu bar" style={{ paddingLeft: ".33em" }}>
             <Tooltip tooltip="Insert table (3x3)">
-              <div id="TABLE_INSERT" class="button wide" onClick={() => table.insertTable(callback)}>
+              <div id="TABLE_INSERT" class="button wide" onClick={() => table.insertTable(tableCallback)}>
                 <SVG text={TableSvgText} />
               </div>
             </Tooltip>
             <Tooltip tooltip="Insert row above">
-              <div id="TABLE_ROW_ABOVE" class="button" onClick={() => table.insertRowAbove(callback)}>
+              <div id="TABLE_ROW_ABOVE" class="button" onClick={() => table.insertRowAbove(tableCallback)}>
                 <SVG text={TableRowAboveSvgText} />
               </div>
             </Tooltip>
             <Tooltip tooltip="Insert row below">
-              <div id="TABLE_ROW_BELOW" class="button" onClick={() => table.insertRowBelow(callback)}>
+              <div id="TABLE_ROW_BELOW" class="button" onClick={() => table.insertRowBelow(tableCallback)}>
                 <SVG text={TableRowBelowSvgText} />
               </div>
             </Tooltip>
             <Tooltip tooltip="Insert column left">
-              <div id="TABLE_COLUMN_LEFT" class="button" onClick={() => table.insertColumnLeft(callback)}>
+              <div id="TABLE_COLUMN_LEFT" class="button" onClick={() => table.insertColumnLeft(tableCallback)}>
                 <SVG text={TableColumnLeftSvgText} />
               </div>
             </Tooltip>
             <Tooltip tooltip="Insert column right">
-              <div id="TABLE_COLUMN_RIGHT" class="button wide" onClick={() => table.insertColumnRight(callback)}>
+              <div id="TABLE_COLUMN_RIGHT" class="button wide" onClick={() => table.insertColumnRight(tableCallback)}>
                 <SVG text={TableColumnRightSvgText} />
               </div>
             </Tooltip>
@@ -144,12 +152,12 @@ const Toolbar = ({ os, note }: ToolbarProps): h.JSX.Element => {
               </div>
             </Tooltip>
             <Tooltip tooltip="Delete row">
-              <div id="TABLE_DELETE_ROW" class="button" onClick={() => table.deleteRow(callback)}>
+              <div id="TABLE_DELETE_ROW" class="button" onClick={() => table.deleteRow(tableCallback)}>
                 <SVG text={TableDeleteRowSvgText} />
               </div>
             </Tooltip>
             <Tooltip tooltip="Delete column">
-              <div id="TABLE_DELETE_COLUMN" class="button" onClick={() => table.deleteColumn(callback)}>
+              <div id="TABLE_DELETE_COLUMN" class="button" onClick={() => table.deleteColumn(tableCallback)}>
                 <SVG text={TableDeleteColumnSvgText} />
               </div>
             </Tooltip>

--- a/src/notes/content/__tests__/table.test.ts
+++ b/src/notes/content/__tests__/table.test.ts
@@ -1,0 +1,154 @@
+import { JSDOM } from "jsdom";
+import {
+  getAllCellsInColumn,
+  MakeTableResizableProps,
+  makeTableResizable,
+  reinitTable,
+} from "../table";
+
+// A B C
+// D E F
+// G H I
+const tableHtml = `<table>
+  <tbody><tr>
+    <td>A</td>
+    <td>B</td>
+    <td>C</td>
+  </tr>
+  <tr>
+    <td>D</td>
+    <td>E</td>
+    <td>F</td>
+  </tr>
+  <tr>
+    <td>G</td>
+    <td>H</td>
+    <td>I</td>
+  </tr></tbody>
+</table>`;
+
+const tableHtmlHoverE = `<table>
+  <tbody><tr>
+    <td>A</td>
+    <td>B<div class="table-resizing-div table-column-resizing-div"></div></td>
+    <td>C</td>
+  </tr>
+  <tr>
+    <td>D<div class="table-resizing-div table-row-resizing-div"></div></td>
+    <td>E<div class="table-resizing-div table-column-resizing-div"></div><div class="table-resizing-div table-row-resizing-div"></div></td>
+    <td>F<div class="table-resizing-div table-row-resizing-div"></div></td>
+  </tr>
+  <tr>
+    <td>G</td>
+    <td>H<div class="table-resizing-div table-column-resizing-div"></div></td>
+    <td>I</td>
+  </tr></tbody>
+</table>`;
+
+const tableHtmlHoverI = `<table>
+  <tbody><tr>
+    <td>A</td>
+    <td>B</td>
+    <td>C<div class="table-resizing-div table-column-resizing-div"></div></td>
+  </tr>
+  <tr>
+    <td>D</td>
+    <td>E</td>
+    <td>F<div class="table-resizing-div table-column-resizing-div"></div></td>
+  </tr>
+  <tr>
+    <td>G<div class="table-resizing-div table-row-resizing-div"></div></td>
+    <td>H<div class="table-resizing-div table-row-resizing-div"></div></td>
+    <td>I<div class="table-resizing-div table-column-resizing-div"></div><div class="table-resizing-div table-row-resizing-div"></div></td>
+  </tr></tbody>
+</table>`;
+
+const prepareDom = (tableHtml: string): { dom: JSDOM, table: HTMLTableElement } => {
+  const dom = new JSDOM();
+  dom.window.document.body.insertAdjacentHTML("afterbegin", tableHtml);
+  const table = dom.window.document.body.children[0] as HTMLTableElement;
+  return { dom, table };
+};
+
+test("getAllCellsInColumn() returns cells in a column", () => {
+  const { table } = prepareDom(tableHtml);
+
+  expect(getAllCellsInColumn(table, 0).map((cell) => cell.innerHTML)).toEqual(["A", "D", "G"]);
+  expect(getAllCellsInColumn(table, 1).map((cell) => cell.innerHTML)).toEqual(["B", "E", "H"]);
+  expect(getAllCellsInColumn(table, 2).map((cell) => cell.innerHTML)).toEqual(["C", "F", "I"]);
+  expect(getAllCellsInColumn(table, 99).map((cell) => cell.innerHTML)).toEqual([]);
+});
+
+describe("reinitTable", () => {
+  let dom: JSDOM;
+  let table: HTMLTableElement;
+  let resizableProps: MakeTableResizableProps;
+  let makeTableResizableFunction: jest.Mock;
+
+  beforeEach(() => {
+    const prepared = prepareDom(tableHtmlHoverE);
+    dom = prepared.dom;
+    table = prepared.table;
+    resizableProps = {
+      document: dom.window.document,
+      computedStyleFunction: dom.window.getComputedStyle,
+      table,
+      onResize: () => { return; }
+    };
+    makeTableResizableFunction = jest.fn();
+    reinitTable({
+      resizableProps,
+      makeTableResizableFunction,
+    });
+  });
+
+  it("removes resizing divs if left over", () => {
+    expect(table.outerHTML).toBe(tableHtml);
+  });
+
+  it("calls resizable function", () => {
+    expect(makeTableResizableFunction).toHaveBeenCalledTimes(1);
+    expect(makeTableResizableFunction).toHaveBeenCalledWith(resizableProps);
+  });
+});
+
+describe("makeTableResizable()", () => {
+  let dom: JSDOM;
+  let table: HTMLTableElement;
+  let onResize: jest.Mock;
+
+  beforeEach(() => {
+    const prepared = prepareDom(tableHtml);
+    dom = prepared.dom;
+    table = prepared.table;
+    onResize = jest.fn(),
+
+    makeTableResizable({
+      document: dom.window.document,
+      computedStyleFunction: dom.window.getComputedStyle,
+      table,
+      onResize,
+    });
+  });
+
+  it("keeps table markup unchanged", () => {
+    expect(table.outerHTML).toBe(tableHtml);
+  });
+
+  it("does NOT call onResize on init", () => {
+    expect(onResize).not.toHaveBeenCalled();
+  });
+
+  it("adds resizing divs on mouseenter, removes them on mouseleave", () => {
+    const enterAndLeave = (cell: HTMLTableCellElement, expectedTableHtmlOnEnter: string) => {
+      cell.dispatchEvent(new dom.window.Event("mouseenter"));
+      expect(table.outerHTML).toBe(expectedTableHtmlOnEnter);
+
+      cell.dispatchEvent(new dom.window.Event("mouseleave"));
+      expect(table.outerHTML).toBe(tableHtml);
+    };
+
+    enterAndLeave(table.rows[1].cells[1], tableHtmlHoverE); // enter and leave E
+    enterAndLeave(table.rows[2].cells[2], tableHtmlHoverI); // enter and leave I
+  });
+});

--- a/src/notes/content/table.ts
+++ b/src/notes/content/table.ts
@@ -1,0 +1,218 @@
+const TABLE_RESIZING_DIV_CLASSNAME = "table-resizing-div";
+const TABLE_COLUMN_RESIZING_DIV_CLASSNAME = "table-column-resizing-div";
+const TABLE_ROW_RESIZING_DIV_CLASSNAME = "table-row-resizing-div";
+
+type ResizingType = "column" | "row";
+type ComputedStyleFunction = (elt: Element) => CSSStyleDeclaration;
+type OnResizeCallback = () => void
+
+export const getAllCellsInColumn = (table: HTMLTableElement, referenceCellIndex: number): HTMLTableCellElement[] => {
+  const cells: HTMLTableCellElement[] = [];
+
+  for (let rowIndex = 0; rowIndex < table.rows.length; rowIndex += 1) {
+    for (let cellIndex = 0; cellIndex < table.rows[rowIndex].cells.length; cellIndex += 1) {
+      if (cellIndex === referenceCellIndex) {
+        cells.push(table.rows[rowIndex].cells[cellIndex]);
+      }
+    }
+  }
+
+  return cells;
+};
+
+const isResizingTable = (document: Document) => document.body.classList.contains("resizing-table");
+
+interface CreateResizingDivProps {
+  document: Document
+  computedStyleFunction: ComputedStyleFunction
+  type: ResizingType
+  table: HTMLTableElement
+  cell: HTMLTableCellElement
+  allCells: HTMLTableCellElement[]
+  onResize: OnResizeCallback
+}
+
+const createResizingDiv = ({
+  document,
+  computedStyleFunction,
+  type,
+  table,
+  cell,
+  allCells,
+  onResize,
+}: CreateResizingDivProps) => {
+  const resizingDiv = document.createElement("div");
+  const specificClassname = type === "column" ? TABLE_COLUMN_RESIZING_DIV_CLASSNAME : TABLE_ROW_RESIZING_DIV_CLASSNAME;
+  resizingDiv.classList.add(TABLE_RESIZING_DIV_CLASSNAME, specificClassname);
+
+  const isLast = allCells[allCells.length - 1] === cell;
+  if (!isLast) {
+    if (type === "column") {
+      resizingDiv.style.bottom = `-${computedStyleFunction(cell).borderBottomWidth}`;
+    }
+
+    if (type === "row") {
+      resizingDiv.style.right = `-${computedStyleFunction(cell).borderRightWidth}`;
+    }
+  }
+
+  const property = type === "column" ? "width" : "height";
+
+  const toggleActiveCells = (toggle: boolean) =>
+    allCells.forEach((oneCell) =>
+      oneCell.querySelector(`.${TABLE_RESIZING_DIV_CLASSNAME}.${specificClassname}`)?.classList.toggle("active", toggle));
+
+  const resizeAllCells = (value: number) => allCells.forEach((oneCell) => {
+    oneCell.style[property] = value + "px";
+    oneCell.style.wordBreak = "break-all";
+  });
+
+  const resetSizeAllCells = () => allCells.forEach((oneCell) => {
+    oneCell.style[property] = "";
+    oneCell.style.wordBreak = "";
+  });
+
+  resizingDiv.addEventListener("mouseenter", () => {
+    if (isResizingTable(document) || cell.querySelector(`.${TABLE_RESIZING_DIV_CLASSNAME}.active`)) {
+      return;
+    }
+    toggleActiveCells(true);
+  });
+
+  const getAchor = (event: MouseEvent) => type === "column" ? event.x : event.y;
+
+  resizingDiv.addEventListener("mousedown", (mousedownEvent) => {
+    document.body.classList.add("resizing-table", `resizing-table-${type}`);
+    table.classList.add("locked");
+
+    let anchor = getAchor(mousedownEvent);
+
+    const mousemoveListener = (mousemoveEvent: MouseEvent): void => {
+      const delta = (anchor - getAchor(mousemoveEvent)) * -1;
+      anchor = getAchor(mousemoveEvent);
+
+      const currentValue = parseInt(computedStyleFunction(cell)[property]);
+      const newValue = currentValue + delta;
+      resizeAllCells(newValue);
+    };
+
+    document.addEventListener("mousemove", mousemoveListener);
+
+    const mouseupListener = () => {
+      if (isResizingTable(document)) {
+        toggleActiveCells(false);
+      }
+      document.body.classList.remove("resizing-table", "resizing-table-column", "resizing-table-row");
+      table.classList.remove("locked");
+      document.removeEventListener("mousemove", mousemoveListener);
+      document.removeEventListener("mouseup", mouseupListener);
+      onResize();
+    };
+
+    document.addEventListener("mouseup", mouseupListener);
+  });
+
+  resizingDiv.addEventListener("dblclick", () => {
+    resetSizeAllCells();
+    onResize();
+  });
+
+  resizingDiv.addEventListener("mouseleave", () => {
+    if (isResizingTable(document)) {
+      return;
+    }
+
+    toggleActiveCells(false);
+  });
+
+  return resizingDiv;
+};
+
+export interface MakeTableResizableProps {
+  document: Document
+  computedStyleFunction: ComputedStyleFunction
+  table: HTMLTableElement
+  onResize: OnResizeCallback
+}
+
+export const makeTableResizable = ({
+  document,
+  computedStyleFunction,
+  table,
+  onResize,
+}: MakeTableResizableProps): void => {
+  for (let rowIndex = 0; rowIndex < table.rows.length; rowIndex += 1) {
+    for (let cellIndex = 0; cellIndex < table.rows[rowIndex].cells.length; cellIndex += 1) {
+      const cell = table.rows[rowIndex].cells[cellIndex];
+
+      const allCellsInColumn = getAllCellsInColumn(table, cellIndex);
+      const allCellsInRow = [...table.rows[rowIndex].cells];
+
+      cell.onmouseleave = () => {
+        if (isResizingTable(document)) {
+          return;
+        }
+        [...allCellsInColumn, ...allCellsInRow].forEach((oneCell) => oneCell.querySelectorAll(`.${TABLE_RESIZING_DIV_CLASSNAME}`).forEach((div) => div.remove()));
+      };
+
+      cell.onmouseenter = () => {
+        if (isResizingTable(document) || cell.querySelector(`.${TABLE_RESIZING_DIV_CLASSNAME}`)) {
+          return;
+        }
+
+        allCellsInColumn.forEach((oneCell) => oneCell.appendChild(createResizingDiv({
+          document,
+          computedStyleFunction,
+          type: "column",
+          table,
+          cell: oneCell,
+          allCells: allCellsInColumn,
+          onResize,
+        })));
+
+        allCellsInRow.forEach((oneCell) => oneCell.appendChild(createResizingDiv({
+          document,
+          computedStyleFunction,
+          type: "row",
+          table,
+          cell: oneCell,
+          allCells: allCellsInRow,
+          onResize,
+        })));
+      };
+    }
+  }
+};
+
+interface ReinitTableProps {
+  resizableProps: MakeTableResizableProps
+  makeTableResizableFunction: (props: MakeTableResizableProps) => void
+}
+
+export const reinitTable = ({ resizableProps, makeTableResizableFunction }: ReinitTableProps): void => {
+  const cells = resizableProps.table.querySelectorAll("td");
+  cells.forEach((oneCell) => {
+    oneCell.onmouseleave = null;
+    oneCell.onmouseenter = null;
+    oneCell.querySelectorAll(`.${TABLE_RESIZING_DIV_CLASSNAME}`).forEach((div) => div.remove());
+  });
+
+  makeTableResizableFunction(resizableProps);
+};
+
+interface ReinitTablesProps {
+  onResize: OnResizeCallback
+}
+
+export const reinitTables = ({ onResize }: ReinitTablesProps): void => {
+  const tables = document.querySelectorAll<HTMLTableElement>("body > #content-container > #content table");
+  tables.forEach((table) => reinitTable({
+    resizableProps: {
+      document,
+      computedStyleFunction: window.getComputedStyle,
+      table,
+      onResize,
+    },
+    makeTableResizableFunction: makeTableResizable,
+  }));
+};

--- a/static/notes.css
+++ b/static/notes.css
@@ -237,6 +237,9 @@ body.resizing-sidebar { cursor: col-resize; }
 body.resizing-sidebar-locked-min { cursor: e-resize; }
 body.resizing-sidebar-locked-max { cursor: w-resize; }
 
+body.resizing-table-column { cursor: col-resize; }
+body.resizing-table-row { cursor: row-resize; }
+
 /* Note */
 
 #content-container {
@@ -284,6 +287,7 @@ body.resizing-sidebar-locked-max { cursor: w-resize; }
   padding: .25em;
   border: var(--table-td-border);
   min-width: 1em;
+  position: relative;
 }
 
 #content table td.heading {
@@ -345,6 +349,38 @@ body.with-control #content a > * {
   background: white;
 }
 
+.my-notes-image {
+  background: #f9f9f9;
+}
+
+/* Table */
+
+.table-resizing-div {
+  position: absolute;
+}
+
+.table-resizing-div.active {
+  background: var(--table-resizing-line-color);
+}
+
+.table-column-resizing-div {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  cursor: col-resize;
+  width: 4px;
+}
+
+.table-row-resizing-div {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  cursor: row-resize;
+  height: 4px;
+}
+
+/* Locked */
+
 body.locked #sidebar,
 body.locked #toolbar,
 #toolbar.locked .button:not(#INFO) {
@@ -361,8 +397,9 @@ body.locked #toolbar,
   opacity: .4;
 }
 
-.my-notes-image {
-  background: #f9f9f9;
+table.locked {
+  user-select: none;
+  -webkit-user-modify: read-only;
 }
 
 /* Command palette */

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -91,6 +91,7 @@
   --table-border: 3px solid #454545;
   --table-td-border: 1px solid #222;
   --table-td-heading-background-color: #222;
+  --table-resizing-line-color: #0000ff;
 
 
   /* Command palette */

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -91,6 +91,7 @@
   --table-border: 3px solid #171717;
   --table-td-border: 1px solid silver;
   --table-td-heading-background-color: #dddddd;
+  --table-resizing-line-color: #0000ff;
 
 
   /* Command palette */


### PR DESCRIPTION
Adds ability to resize table columns and rows.

### How it works

Move your mouse over any column/row separator line. It will change to blue (color is customizable). Drag the blue line to start resizing the column/row. Release the mouse to stop resizing. Double-click on the blue line to reset the size of column/row. All changes are saved automatically and don't require any further actions.

### How to customize

If you're using a Custom theme, you can customize the resizing color (default: blue) to any color you'd like. The CSS variable is called `--table-resizing-line-color`. See `light.css` or `dark.css` for reference.

<br>

Closes https://github.com/penge/my-notes/issues/155