### PR TITLE
Implement custom notes order

### DIFF
--- a/src/background/init/migrations/__tests__/core-custom-values.test.ts
+++ b/src/background/init/migrations/__tests__/core-custom-values.test.ts
@@ -1,4 +1,4 @@
-import { Storage } from "shared/storage/schema";
+import { NotesOrder, Storage } from "shared/storage/schema";
 import migrate from "../core";
 import { expectItems } from "./core-default-values.test";
 
@@ -58,6 +58,8 @@ it("sets custom values", () => {
   // Compare objects
   expect(items).toEqual(Object.assign({
     // Automatically added properties to make a complete object (interface Storage)
+    order: [],
+    notesOrder: NotesOrder.Alphabetical,
     sidebar: true,
     toolbar: true,
     autoSync: false,

--- a/src/background/init/migrations/core.ts
+++ b/src/background/init/migrations/core.ts
@@ -1,13 +1,15 @@
 
-import { NotesObject, Storage } from "shared/storage/schema";
+import { NotesObject, NotesOrder, Storage } from "shared/storage/schema";
 import { defaultValuesFactory } from "shared/storage/default-values";
 import {
   validBoolean,
+  validStringArray,
   validCustomTheme,
   validFont,
   validSize,
   validTabSize,
-  validTheme
+  validTheme,
+  validNotesOrder,
 } from "shared/storage/validations";
 
 export const expectedKeys = [
@@ -21,11 +23,13 @@ export const expectedKeys = [
 
   // Notes
   "notes",
+  "order",
   "active",
   "setBy",
   "lastEdit",
 
   // Options
+  "notesOrder",
   "focus",
   "tab",
   "tabSize",
@@ -81,11 +85,13 @@ export default (sync: { [key: string]: unknown }, local: { [key: string]: unknow
 
     // Notes
     notes: notes as NotesObject, // already migrated to [3.x]
+    order: validStringArray(local.order) ? local.order : [],
     active: tryNote(local.active as string) || tryNote(defaultValues.active as string) || firstAvailableNote,
     setBy: local.setBy as string || "",
     lastEdit: local.lastEdit as string || "",
 
     // Options
+    notesOrder: validNotesOrder(local.notesOrder) ? local.notesOrder : NotesOrder.Alphabetical,
     focus: validBoolean(local.focus) ? local.focus : defaultValues.focus,
     tab: validBoolean(local.tab) ? local.tab : defaultValues.tab,
     tabSize: validTabSize(local.tabSize) ? local.tabSize : defaultValues.tabSize,

--- a/src/notes/adapters/__tests__/index.ts
+++ b/src/notes/adapters/__tests__/index.ts
@@ -1,0 +1,29 @@
+import { NotesObject, NotesOrder } from "shared/storage/schema";
+import { notesToSidebarNotes } from "../";
+
+test("notesToSidebarNotes() returns notes suitable for the Sidebar", () => {
+  const notes: NotesObject = {
+    Todo: {
+      content: "my todo",
+      createdTime: "CT-TODO",
+      modifiedTime: "MT-TODO",
+    },
+    Article: {
+      content: "my article",
+      createdTime: "CT-ARTICLE",
+      modifiedTime: "MT-ARTICLE",
+    },
+    Shopping: {
+      content: "my shopping",
+      createdTime: "CT-SHOPPING",
+      modifiedTime: "MT-SHOPPING",
+    },
+  };
+
+  const sidebarNotes = notesToSidebarNotes(notes, NotesOrder.Alphabetical);
+  expect(sidebarNotes).toEqual([
+    { name: "Article", ...notes.Article },
+    { name: "Shopping", ...notes.Shopping },
+    { name: "Todo", ...notes.Todo },
+  ]);
+});

--- a/src/notes/adapters/index.ts
+++ b/src/notes/adapters/index.ts
@@ -1,0 +1,19 @@
+import { sortNotes } from "notes/sort";
+import { NotesObject, Note, NotesOrder } from "shared/storage/schema";
+
+export interface SidebarNote extends Note {
+  name: string
+}
+
+export const notesToSidebarNotes = (
+  notes: NotesObject,
+  notesOrder: NotesOrder,
+  custom?: string[],
+): SidebarNote[] => {
+  const unsorted = Object.keys(notes).map((noteName) => ({
+    name: noteName,
+    ...notes[noteName],
+  }));
+
+  return sortNotes(unsorted, notesOrder, custom);
+};

--- a/src/notes/components/Sidebar.tsx
+++ b/src/notes/components/Sidebar.tsx
@@ -1,39 +1,16 @@
-import { h, Fragment } from "preact";
-import { useRef, useCallback, useEffect, useState } from "preact/hooks";
-import clsx from "clsx";
-import { Os, Sync, MessageType, NotesObject } from "shared/storage/schema";
+import { h } from "preact";
+import { useRef } from "preact/hooks";
+import { Os, Sync } from "shared/storage/schema";
+import { SidebarNote } from "notes/adapters";
+import SidebarNotes from "./SidebarNotes";
+import SidebarButtons from "./SidebarButtons";
 import Drag from "./Drag";
-import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
-import formatDate from "shared/date/format-date";
-import { sendMessage } from "messages";
-import Tooltip from "./Tooltip";
-import { importNoteFromTxtFile } from "notes/import";
-
-import FileSvgText from "svg/file.svg";
-import GearSvgText from "svg/gear.svg";
-import RefreshSvgText from "svg/refresh.svg";
-import LockSvgText from "svg/lock.svg";
-import SVG from "types/SVG";
-
-const syncNowTitles = {
-  mac: (lastSync: string) => (
-    <Fragment>
-      <div>Click to sync notes to and from Google Drive (⌘ + R)</div>
-      <div>Last sync: {formatDate(lastSync)}</div>
-    </Fragment>
-  ),
-  other: (lastSync: string) => (
-    <Fragment>
-      <div>Click to sync notes to and from Google Drive (Ctrl + R)</div>
-      <div>Last sync: {formatDate(lastSync)}</div>
-    </Fragment>
-  ),
-  disabled: "Google Drive Sync is disabled (see Options)",
-};
 
 interface SidebarProps {
   os?: Os
-  notes: NotesObject
+  notes: SidebarNote[]
+  canChangeOrder: boolean
+  onChangeOrder: (newOrder: string[]) => void
   active: string
   width?: string
   onActivateNote: (noteName: string) => void
@@ -43,148 +20,33 @@ interface SidebarProps {
 }
 
 const Sidebar = ({
-  os, notes, active, width, onActivateNote, onNoteContextMenu, onNewNote, sync,
+  os, notes, canChangeOrder, onChangeOrder, active, width, onActivateNote, onNoteContextMenu, onNewNote, sync,
 }: SidebarProps): h.JSX.Element => {
   const sidebarRef = useRef<HTMLDivElement>(null);
 
-  const [dragOverNote, setDragOverNote] = useState<string | null>(null);
-  const [dragOverNoteConfirmation, setDragOverNoteConfirmation] = useState<string | null>(null);
-
-  const [enteredNote, setEnteredNote] = useState<string | null>(null);
-  const enteredNoteRef = useRef<string | null>(null);
-  enteredNoteRef.current = enteredNote;
-
-  const [dragOverButtons, setDragOverButtons] = useState<boolean>(false);
-
-  const openOptions = useCallback(() => chrome.runtime.openOptionsPage(), []);
-  const openEnteredNote = useCallback(() => {
-    if (!document.body.classList.contains("with-control")) {
-      return;
-    }
-
-    const note = enteredNoteRef.current;
-    if (!note || note === active) {
-      return;
-    }
-
-    onActivateNote(note);
-  }, [onActivateNote]);
-
-  useEffect(openEnteredNote, [enteredNote]);
-  useEffect(() => {
-    keyboardShortcuts.subscribe(KeyboardShortcut.OnControl, () => {
-      document.body.classList.add("with-control");
-      openEnteredNote();
-    });
-  }, []);
-
-  useEffect(() => {
-    setDragOverNote(null);
-    setDragOverNoteConfirmation(null);
-  }, [active]);
-
   return (
-    <div id="sidebar" ref={sidebarRef} style={{
-      width: width,
-      minWidth: width,
-    }}>
-      <div id="sidebar-notes" class="notes">
-        {Object.keys(notes).map((noteName) =>
-          <div
-            class={clsx(
-              "note",
-              noteName === active && "active",
-              noteName === dragOverNote && "drag-over",
-              noteName === dragOverNoteConfirmation && "drag-confirmation",
-            )}
-            onClick={() => onActivateNote(noteName)}
-            onMouseEnter={() => setEnteredNote(noteName)}
-            onMouseLeave={() => setEnteredNote(null)}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              onActivateNote(noteName);
-              onNoteContextMenu(noteName, event.pageX, event.pageY);
-            }}
-            onDragOver={(event) => {
-              if (notes[noteName].locked) {
-                return;
-              }
-              event.preventDefault();
-              setDragOverNote(noteName);
-              setDragOverNoteConfirmation(null);
-            }}
-            onDragLeave={(event) => {
-              if (notes[noteName].locked) {
-                return;
-              }
-              event.preventDefault();
-              setDragOverNote(null);
-            }}
-            onDrop={(event) => {
-              if (notes[noteName].locked) {
-                return;
-              }
-              event.preventDefault();
-              const data = event.dataTransfer?.getData("text");
-              if (data) {
-                sendMessage(MessageType.DROP, {
-                  targetNoteName: noteName,
-                  data,
-                });
-                setDragOverNoteConfirmation(noteName);
-              }
-              setDragOverNote(null);
-            }}
-          >
-            {noteName}
-            {notes[noteName].locked && <SVG text={LockSvgText} />}
-          </div>
-        )}
-      </div>
+    <div
+      id="sidebar"
+      ref={sidebarRef}
+      style={{
+        width: width,
+        minWidth: width,
+      }}
+    >
+      <SidebarNotes
+        notes={notes}
+        active={active}
+        onActivateNote={onActivateNote}
+        onNoteContextMenu={onNoteContextMenu}
+        canChangeOrder={canChangeOrder}
+        onChangeOrder={onChangeOrder}
+      />
 
-      <div
-        id="sidebar-buttons"
-        class={clsx("bar", dragOverButtons && "drag-over")}
-        onDragOver={(event) => {
-          event.preventDefault();
-          setDragOverButtons(true);
-        }}
-        onDragLeave={(event) => {
-          event.preventDefault();
-          setDragOverButtons(false);
-        }}
-        onDrop={(event) => {
-          event.preventDefault();
-          const file = event.dataTransfer?.files[0];
-          if (!file) {
-            setDragOverButtons(false);
-            return;
-          }
-
-          importNoteFromTxtFile(file, () => setDragOverButtons(false));
-        }}
-      >
-        <Tooltip tooltip="New note">
-          <div id="new-note" class="button" onClick={onNewNote}>
-            <SVG text={FileSvgText} />
-          </div>
-        </Tooltip>
-
-        <Tooltip tooltip="Options">
-          <div id="open-options" class="button" onClick={openOptions}>
-            <SVG text={GearSvgText} />
-          </div>
-        </Tooltip>
-
-        <Tooltip id="sync-now-tooltip" tooltip={(sync && sync.lastSync) ? (os ? syncNowTitles[os](sync.lastSync) : "") : syncNowTitles.disabled}>
-          <div id="sync-now"
-            class={clsx("button", (!sync || !sync.lastSync) && "disabled")}
-            onClick={() => sendMessage(MessageType.SYNC)}
-          >
-            <SVG text={RefreshSvgText} />
-          </div>
-        </Tooltip>
-      </div>
+      <SidebarButtons
+        os={os}
+        sync={sync}
+        onNewNote={onNewNote}
+      />
 
       <Drag sidebar={sidebarRef} />
     </div>

--- a/src/notes/components/SidebarButtons.tsx
+++ b/src/notes/components/SidebarButtons.tsx
@@ -1,0 +1,89 @@
+import { h, Fragment } from "preact";
+import { useState, useCallback } from "preact/hooks";
+import { Os, Sync, MessageType } from "shared/storage/schema";
+import clsx from "clsx";
+import Tooltip from "./Tooltip";
+import SVG from "types/SVG";
+import FileSvgText from "svg/file.svg";
+import GearSvgText from "svg/gear.svg";
+import RefreshSvgText from "svg/refresh.svg";
+import { importNoteFromTxtFile } from "notes/import";
+import { sendMessage } from "messages";
+import formatDate from "shared/date/format-date";
+
+const syncNowTitles = {
+  mac: (lastSync: string) => (
+    <Fragment>
+      <div>Click to sync notes to and from Google Drive (⌘ + R)</div>
+      <div>Last sync: {formatDate(lastSync)}</div>
+    </Fragment>
+  ),
+  other: (lastSync: string) => (
+    <Fragment>
+      <div>Click to sync notes to and from Google Drive (Ctrl + R)</div>
+      <div>Last sync: {formatDate(lastSync)}</div>
+    </Fragment>
+  ),
+  disabled: "Google Drive Sync is disabled (see Options)",
+};
+
+interface SidebarButtonsProps {
+  os?: Os
+  sync?: Sync
+  onNewNote: () => void
+}
+
+const SidebarButtons = ({
+  os, sync, onNewNote,
+}: SidebarButtonsProps): h.JSX.Element => {
+  const [dragOver, setDragOver] = useState<boolean>(false);
+  const openOptions = useCallback(() => chrome.runtime.openOptionsPage(), []);
+
+  return (
+    <div
+      id="sidebar-buttons"
+      class={clsx("bar", dragOver && "drag-over")}
+      onDragOver={(event) => {
+        event.preventDefault();
+        setDragOver(true);
+      }}
+      onDragLeave={(event) => {
+        event.preventDefault();
+        setDragOver(false);
+      }}
+      onDrop={(event) => {
+        event.preventDefault();
+        const file = event.dataTransfer?.files[0];
+        if (!file) {
+          setDragOver(false);
+          return;
+        }
+
+        importNoteFromTxtFile(file, () => setDragOver(false));
+      }}
+    >
+      <Tooltip tooltip="New note">
+        <div id="new-note" class="button" onClick={onNewNote}>
+          <SVG text={FileSvgText} />
+        </div>
+      </Tooltip>
+
+      <Tooltip tooltip="Options">
+        <div id="open-options" class="button" onClick={openOptions}>
+          <SVG text={GearSvgText} />
+        </div>
+      </Tooltip>
+
+      <Tooltip id="sync-now-tooltip" tooltip={(sync && sync.lastSync) ? (os ? syncNowTitles[os](sync.lastSync) : "") : syncNowTitles.disabled}>
+        <div id="sync-now"
+          class={clsx("button", (!sync || !sync.lastSync) && "disabled")}
+          onClick={() => sync && sendMessage(MessageType.SYNC)}
+        >
+          <SVG text={RefreshSvgText} />
+        </div>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default SidebarButtons;

--- a/src/notes/components/SidebarNotes.tsx
+++ b/src/notes/components/SidebarNotes.tsx
@@ -1,0 +1,168 @@
+import { Fragment, h } from "preact";
+import { useState, useEffect, useCallback, useRef } from "preact/hooks";
+import { MessageType } from "shared/storage/schema";
+import { SidebarNote } from "notes/adapters";
+import clsx from "clsx";
+import SVG from "types/SVG";
+import LockSvgText from "svg/lock.svg";
+import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
+import { sendMessage } from "messages";
+
+interface SidebarNotesProps {
+  notes: SidebarNote[]
+  active: string
+  onActivateNote: (noteName: string) => void
+  onNoteContextMenu: (noteName: string, x: number, y: number) => void
+  canChangeOrder: boolean
+  onChangeOrder: (newOrder: string[]) => void
+}
+
+const SidebarNotes = ({
+  notes: sidebarNotes, active, onActivateNote, onNoteContextMenu, canChangeOrder, onChangeOrder,
+}: SidebarNotesProps): h.JSX.Element => {
+  const [notes, setNotes] = useState<SidebarNote[]>(sidebarNotes);
+
+  const [draggedNote, setDraggedNote] = useState<SidebarNote | null>(null);
+  const [dragOverNote, setDragOverNote] = useState<string | null>(null);
+  const [dragOverNoteConfirmation, setDragOverNoteConfirmation] = useState<string | null>(null);
+
+  const [enteredNote, setEnteredNote] = useState<string | null>(null);
+  const enteredNoteRef = useRef<string | null>(null);
+  enteredNoteRef.current = enteredNote;
+
+  const openEnteredNote = useCallback(() => {
+    if (!document.body.classList.contains("with-control")) {
+      return;
+    }
+
+    const note = enteredNoteRef.current;
+    if (!note || note === active) {
+      return;
+    }
+
+    onActivateNote(note);
+  }, [onActivateNote]);
+
+  useEffect(() => {
+    setDragOverNote(null);
+    setDragOverNoteConfirmation(null);
+  }, [active]);
+
+  useEffect(() => setNotes(sidebarNotes), [sidebarNotes]);
+  useEffect(openEnteredNote, [enteredNote]);
+
+  useEffect(() => {
+    const onControlHandle = () => {
+      document.body.classList.add("with-control");
+      openEnteredNote();
+    };
+
+    keyboardShortcuts.subscribe(KeyboardShortcut.OnControl, onControlHandle);
+    return () => keyboardShortcuts.unsubscribe(onControlHandle);
+  }, []);
+
+  return (
+    <Fragment>
+      <div
+        id="sidebar-notes"
+        className={clsx("notes", draggedNote && "dragging")}
+      >
+        {notes.map((note, index) =>
+          <div
+            draggable
+            class={clsx(
+              "note",
+              note.name === active && "active",
+              note.name === dragOverNote && "drag-over",
+              note.name === dragOverNoteConfirmation && "drag-confirmation",
+              note === draggedNote && "dragging",
+            )}
+            onClick={() => onActivateNote(note.name)}
+            onMouseEnter={() => !draggedNote && setEnteredNote(note.name)}
+            onMouseLeave={() => !draggedNote && setEnteredNote(null)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              onActivateNote(note.name);
+              onNoteContextMenu(note.name, event.pageX, event.pageY);
+            }}
+            onDragStart={(event) => {
+              if (!canChangeOrder) {
+                event.preventDefault();
+                return;
+              }
+
+              if (event.dataTransfer) {
+                event.dataTransfer.effectAllowed = "move";
+              }
+            }}
+            onDrag={() => {
+              if (draggedNote) {
+                return;
+              }
+
+              setDraggedNote(note);
+            }}
+            onDragEnter={() => {
+              if (!draggedNote) {
+                return;
+              }
+
+              setNotes((prev) => {
+                const newNotes = [...prev];
+                const draggedNoteIndex = newNotes.indexOf(draggedNote);
+                newNotes[index] = draggedNote;
+                newNotes[draggedNoteIndex] = note;
+
+                return newNotes;
+              });
+            }}
+            onDragOver={(event) => {
+              event.preventDefault();
+              if (note.locked || draggedNote) {
+                return;
+              }
+
+              setDragOverNote(note.name);
+              setDragOverNoteConfirmation(null);
+            }}
+            onDragLeave={(event) => {
+              event.preventDefault();
+              if (note.locked || draggedNote) {
+                return;
+              }
+              setDragOverNote(null);
+            }}
+            onDrop={(event) => {
+              if (note.locked) {
+                return;
+              }
+
+              event.preventDefault();
+              const data = event.dataTransfer?.getData("text");
+              if (data) {
+                sendMessage(MessageType.DROP, {
+                  targetNoteName: note.name,
+                  data,
+                });
+                setDragOverNoteConfirmation(note.name);
+              }
+
+              setDragOverNote(null);
+            }}
+            onDragEnd={() => {
+              setDraggedNote(null);
+
+              const newOrder = notes.map((sidebarNote) => sidebarNote.name);
+              onChangeOrder(newOrder);
+            }}
+          >
+            {note.name}
+            {note.locked && <SVG text={LockSvgText} />}
+          </div>
+        )}
+      </div>
+    </Fragment>
+  );
+};
+
+export default SidebarNotes;

--- a/src/notes/sort/__tests__/index.ts
+++ b/src/notes/sort/__tests__/index.ts
@@ -1,0 +1,63 @@
+import { SidebarNote } from "notes/adapters";
+import { NotesOrder } from "shared/storage/schema";
+import { sortNotes } from "..";
+
+const notes: SidebarNote[] = [
+  {
+    name: "Clipboard",
+    content: "my todo",
+    createdTime: "CT1",
+    modifiedTime: "MT4",
+  },
+  {
+    name: "Todo",
+    content: "my todo",
+    createdTime: "CT2",
+    modifiedTime: "MT8",
+  },
+  {
+    name: "Article",
+    content: "my article",
+    createdTime: "CT4",
+    modifiedTime: "MT3",
+  },
+  {
+    name: "Shopping",
+    content: "my shopping",
+    createdTime: "CT3",
+    modifiedTime: "MT7",
+  },
+];
+
+const nameMap = (item: SidebarNote) => item.name;
+
+test("sortNotes() sorts notes in Alphabetical order", () => {
+  expect(
+    sortNotes(notes, NotesOrder.Alphabetical).map(nameMap)
+  ).toEqual(["Article", "Clipboard", "Shopping", "Todo"]);
+});
+
+test("sortNotes() sorts notes in NewestFirst order", () => {
+  expect(
+    sortNotes(notes, NotesOrder.NewestFirst).map(nameMap)
+  ).toEqual(["Todo", "Shopping", "Clipboard", "Article"]);
+});
+
+test("sortNotes() sorts notes in Custom order", () => {
+  const custom = ["Article", "Todo", "Clipboard", "Shopping"];
+  expect(
+    sortNotes(notes, NotesOrder.Custom, custom).map(nameMap)
+  ).toEqual(custom);
+});
+
+test("sortNotes() returns original order when custom order is not provided", () => {
+  const original = notes.map(nameMap);
+
+  expect(
+    sortNotes(notes, NotesOrder.Custom).map(nameMap) // "custom" is not provided
+  ).toEqual(original);
+
+  expect(
+    sortNotes(notes, NotesOrder.Custom, []).map(nameMap) // "custom" is empty
+  ).toEqual(original);
+});

--- a/src/notes/sort/index.ts
+++ b/src/notes/sort/index.ts
@@ -1,0 +1,18 @@
+import { SidebarNote } from "notes/adapters";
+import { NotesOrder } from "shared/storage/schema";
+
+export const sortNotes = (notes: SidebarNote[], notesOrder: NotesOrder, custom?: string[]): SidebarNote[] => {
+  if (notesOrder === NotesOrder.Alphabetical) {
+    return notes.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  if (notesOrder === NotesOrder.NewestFirst) {
+    return notes.sort((a, b) => -a.modifiedTime.localeCompare(b.modifiedTime));
+  }
+
+  if (custom?.length) {
+    return notes.sort((a, b) => custom.indexOf(a.name) - custom.indexOf(b.name));
+  }
+
+  return notes;
+};

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "preact/hooks";
 
 import __Font from "options/Font";
 import __Size from "options/Size";
+import __NotesOrder from "options/NotesOrder";
 import __Theme from "options/Theme";
 import __KeyboardShortcuts from "options/KeyboardShortcuts";
 import __Options from "options/Options";
@@ -13,6 +14,7 @@ import {
   Os,
   Storage,
   NotesObject,
+  NotesOrder,
   RegularFont,
   GoogleFont,
   Theme,
@@ -24,6 +26,7 @@ const Options = (): h.JSX.Element => {
   const [os, setOs] = useState<Os | undefined>(undefined);
   const [version] = useState<string>(chrome.runtime.getManifest().version);
   const [notesCount, setNotesCount] = useState<number>(0);
+  const [notesOrder, setNotesOrder] = useState<NotesOrder>(NotesOrder.Alphabetical);
   const [font, setFont] = useState<RegularFont | GoogleFont | undefined>(undefined);
   const [size, setSize] = useState<number>(0);
   const [theme, setTheme] = useState<Theme | undefined>(undefined);
@@ -37,38 +40,48 @@ const Options = (): h.JSX.Element => {
     chrome.runtime.getPlatformInfo((platformInfo) => setOs(platformInfo.os === "mac" ? "mac" : "other"));
 
     chrome.storage.local.get([
-      "notes",
+      // Appearance
       "font",
       "size",
       "theme",
       "customTheme",
-      "sync",
-      "autoSync",
+
+      // Notes
+      "notes",
+
+      // Options
+      "notesOrder",
       "tab",
       "tabSize",
+      "autoSync",
+
+      // Sync
+      "sync",
     ], items => {
       const local = items as Storage;
 
-      setNotesCount(Object.keys(local.notes).length);
+      // Appearance
       setFont(local.font);
       setSize(local.size);
       setTheme(local.theme);
       setCustomTheme(local.customTheme);
-      setSync(local.sync);
-      setAutoSync(local.autoSync);
+
+      // Notes
+      setNotesCount(Object.keys(local.notes).length);
+
+      // Options
+      setNotesOrder(local.notesOrder);
       setTab(local.tab);
       setTabSize(local.tabSize);
+      setAutoSync(local.autoSync);
+
+      // Sync
+      setSync(local.sync);
     });
 
     chrome.storage.onChanged.addListener((changes, areaName) => {
       if (areaName !== "local") {
         return;
-      }
-
-      if (changes["notes"]) {
-        const newValue: NotesObject = changes["notes"].newValue;
-        const newNotesCount = Object.keys(newValue).length;
-        setNotesCount(newNotesCount);
       }
 
       if (changes["font"]) {
@@ -87,12 +100,14 @@ const Options = (): h.JSX.Element => {
         setCustomTheme(changes["customTheme"].newValue);
       }
 
-      if (changes["sync"]) {
-        setSync(changes["sync"].newValue);
+      if (changes["notes"]) {
+        const newValue: NotesObject = changes["notes"].newValue;
+        const newNotesCount = Object.keys(newValue).length;
+        setNotesCount(newNotesCount);
       }
 
-      if (changes["autoSync"]) {
-        setAutoSync(changes["autoSync"].newValue);
+      if (changes["notesOrder"]) {
+        setNotesOrder(changes["notesOrder"].newValue);
       }
 
       if (changes["tab"]) {
@@ -101,6 +116,14 @@ const Options = (): h.JSX.Element => {
 
       if (changes["tabSize"]) {
         setTabSize(changes["tabSize"].newValue);
+      }
+
+      if (changes["autoSync"]) {
+        setAutoSync(changes["autoSync"].newValue);
+      }
+
+      if (changes["sync"]) {
+        setSync(changes["sync"].newValue);
       }
     });
   }, []);
@@ -119,6 +142,7 @@ const Options = (): h.JSX.Element => {
 
       <__Font font={font} />
       <__Size size={size} />
+      <__NotesOrder notesOrder={notesOrder} />
       <__Theme theme={theme} />
       {os && <__KeyboardShortcuts os={os} />}
       <__Options

--- a/src/options/Font.tsx
+++ b/src/options/Font.tsx
@@ -29,7 +29,10 @@ const Font = ({ font }: FontProps): h.JSX.Element => {
   return (
     <Fragment>
       <h2>Font</h2>
-      <p>Current font: <span id="current-font-name">{font?.name}</span></p>
+      <p>
+        <span>Current font: </span>
+        <span id="current-font-name">{font?.name}</span>
+      </p>
 
       {/* Title containing font family names (current underlined) */}
       <h3>

--- a/src/options/NotesOrder.tsx
+++ b/src/options/NotesOrder.tsx
@@ -1,0 +1,30 @@
+import { h, Fragment } from "preact";
+import { NotesOrder as NotesOrderEnum } from "shared/storage/schema";
+
+interface OrderProps {
+  notesOrder: NotesOrderEnum
+}
+
+const NotesOrder = ({ notesOrder }: OrderProps): h.JSX.Element => (
+  <Fragment>
+    <h2>Order</h2>
+    <p>
+      <span>Current order: </span>
+      <select
+        class="select"
+        value={notesOrder}
+        onChange={(event) => {
+          const newNotesOrder = (event.target as HTMLSelectElement).value as NotesOrderEnum;
+          chrome.storage.local.set({ notesOrder: newNotesOrder });
+        }}
+      >
+        <option value={NotesOrderEnum.Alphabetical}>Alphabetical</option>
+        <option value={NotesOrderEnum.NewestFirst}>Newest first</option>
+        <option value={NotesOrderEnum.Custom}>Custom</option>
+      </select>
+    </p>
+    <p>When <b>"Custom"</b> is selected, you can <b>Drag & Drop</b> notes to change their order.</p>
+  </Fragment>
+);
+
+export default NotesOrder;

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -94,10 +94,14 @@ const Options = ({ sync, autoSync, tab, tabSize }: OptionsProps): h.JSX.Element 
             </div>
             <div class={clsx("space-top", !tab && "disabled")}>
               <label>Tab size:</label>
-              <select name="tab-size" class="select" value={tabSize} onChange={(event) => {
-                const newTabSize: number = parseInt((event.target as HTMLSelectElement).value);
-                chrome.storage.local.set({ tabSize: newTabSize });
-              }}>
+              <select
+                class="select"
+                value={tabSize}
+                onChange={(event) => {
+                  const newTabSize: number = parseInt((event.target as HTMLSelectElement).value);
+                  chrome.storage.local.set({ tabSize: newTabSize });
+                }}
+              >
                 <option value="-1">Tab</option>
                 <option value="2">2 spaces</option>
                 <option value="4">4 spaces</option>

--- a/src/options/Version.tsx
+++ b/src/options/Version.tsx
@@ -8,7 +8,7 @@ const Version = ({ version }: VersionProps): h.JSX.Element => (
   <Fragment>
     <h2>Version</h2>
     <div>
-      <strong id="version" class="space-right">{version}</strong>
+      <strong id="version">{version}</strong>
       <a href="https://github.com/penge/my-notes/releases" target="_blank" class="space-left">Changelog</a>
       <a href="https://github.com/penge/my-notes" target="_blank" class="space-left">Homepage</a>
       <br />

--- a/src/shared/storage/default-values.ts
+++ b/src/shared/storage/default-values.ts
@@ -1,5 +1,6 @@
 import {
   NotesObject,
+  NotesOrder,
   Storage,
 } from "./schema";
 
@@ -34,11 +35,13 @@ const defaultValuesFactory = (generateNotes?: boolean): Storage => {
 
     // Notes
     notes,
+    order: [],
     active: "One",
     setBy: "",
     lastEdit: "",
 
     // Options
+    notesOrder: NotesOrder.Alphabetical,
     focus: false,
     tab: false,
     tabSize: -1,

--- a/src/shared/storage/schema.ts
+++ b/src/shared/storage/schema.ts
@@ -58,6 +58,12 @@ export type NotesObject = {
   [key: string]: Note
 }
 
+export enum NotesOrder {
+  Alphabetical = "Alphabetical",
+  NewestFirst = "NewestFirst",
+  Custom = "Custom",
+}
+
 export interface Storage {
   // Notifications
   notification?: Notification
@@ -73,11 +79,13 @@ export interface Storage {
 
   // Notes
   notes: NotesObject
+  order: string[]
   active: string | null
   setBy: string     // e.g. "worker-[ISOString]", "[tabId]-[ISOString]"
   lastEdit: string  // e.g. "[ISOString]"
 
   // Options
+  notesOrder: NotesOrder
   focus: boolean
   tab: boolean
   tabSize: number

--- a/src/shared/storage/validations.ts
+++ b/src/shared/storage/validations.ts
@@ -1,4 +1,4 @@
-import { RegularFont, GoogleFont, Theme } from "./schema";
+import { RegularFont, GoogleFont, Theme, NotesOrder } from "./schema";
 
 export const validFont = (obj: unknown): obj is RegularFont | GoogleFont => {
   const isRegularFont = typeof obj === "object" && obj !== null
@@ -36,6 +36,14 @@ export const validBoolean = (value: unknown): value is boolean => {
   return typeof value === "boolean";
 };
 
+export const validStringArray = (value: unknown): value is Array<string> => {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+};
+
 export const validTabSize = (value: unknown): value is number => {
   return typeof value === "number" && [-1, 2, 4].includes(value);
+};
+
+export const validNotesOrder = (value: unknown): value is NotesOrder => {
+  return Object.values(NotesOrder).includes(value as NotesOrder);
 };

--- a/static/notes.css
+++ b/static/notes.css
@@ -190,6 +190,20 @@ body:not(.with-sidebar) { left: 0 !important; }
   animation: confirmation .3s cubic-bezier(1, 0, 0.5, 1) 2 alternate;
 }
 
+#sidebar-notes.dragging .note,
+#sidebar-notes.dragging .note.active,
+#sidebar-notes.dragging .note.drag-over {
+  background: none !important;
+  color: var(--sidebar-notes-text-color) !important;
+}
+
+#sidebar-notes.dragging .note.dragging {
+  background: transparent !important;
+  color: transparent !important;
+  box-shadow: inset 0 0 0px 1px silver;
+  cursor: grabbing;
+}
+
 #sidebar-buttons .button {
   cursor: pointer;
 }

--- a/static/options.css
+++ b/static/options.css
@@ -83,7 +83,6 @@ body#dark .comment {
 /* Font type */
 
 #current-font-name {
-  padding: 0 8px;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Notes in the Sidebar can now be sorted in one of 3 possible ways:
- **Alphabetical** (from A to Z; **default**)
- **Newest first** (latest edited at the top)
- **Custom** (Drag & Drop notes to change their order)

This new setting can be found in Options under a new section **Order.**


Closes https://github.com/penge/my-notes/issues/129
Closes https://github.com/penge/my-notes/issues/167