### PR TITLE
Add `useBodyClass` hook

### DIFF
--- a/src/notes/components/CommandPalette.tsx
+++ b/src/notes/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { h } from "preact";
 import { useRef, useState, useMemo, useCallback, useEffect } from "preact/hooks";
+import { useBodyClass } from "notes/hooks/use-body-class";
 import { NotesObject } from "shared/storage/schema";
 import clsx from "clsx";
 
@@ -77,6 +78,8 @@ export const prepareItems = (notes: NotesObject, commands: string[], filter: Fil
 };
 
 const CommandPalette = ({ notes, commands, onActivateNote, onExecuteCommand }: CommandPaletteProps): h.JSX.Element => {
+  useBodyClass("with-command-palette");
+
   const inputRef = useRef<HTMLInputElement>(null);
   const [filter, setFilter] = useState<Filter | undefined>(undefined);
 
@@ -96,11 +99,6 @@ const CommandPalette = ({ notes, commands, onActivateNote, onExecuteCommand }: C
     onActivateNote(name);
     return;
   }, [filter, onActivateNote, onExecuteCommand]);
-
-  useEffect(() => {
-    document.body.classList.add("with-command-palette");
-    return () => document.body.classList.remove("with-command-palette");
-  }, []);
 
   useEffect(() => inputRef.current?.focus(), [inputRef]); // auto-focus the input when Command Palette is open
 

--- a/src/notes/components/Overlay.tsx
+++ b/src/notes/components/Overlay.tsx
@@ -1,19 +1,14 @@
 import { h } from "preact";
-import { useEffect } from "preact/hooks";
+import { useBodyClass } from "notes/hooks/use-body-class";
 
 interface OverlayProps {
   type: "to-rename" | "to-delete" | "to-create"
 }
 
 const Overlay = ({ type }: OverlayProps): h.JSX.Element => {
-  useEffect(() => {
-    document.body.classList.add("with-overlay", type);
-    return () => {
-      document.body.classList.remove("with-overlay", type);
-    };
-  }, []);
+  useBodyClass("with-overlay");
 
-  return <div id="overlay"></div>;
+  return <div id="overlay" className={type}></div>;
 };
 
 export default Overlay;

--- a/src/notes/components/modals/DeleteNoteModal.tsx
+++ b/src/notes/components/modals/DeleteNoteModal.tsx
@@ -4,7 +4,7 @@ import Modal from "./Modal";
 export interface DeleteNoteModalProps {
   noteName: string
   onCancel: () => void
-  onConfirm: (newNoteName: string) => void
+  onConfirm: () => void
 }
 
 const DeleteNoteModal = ({ noteName, onCancel, onConfirm }: DeleteNoteModalProps): h.JSX.Element => (

--- a/src/notes/components/modals/Modal.tsx
+++ b/src/notes/components/modals/Modal.tsx
@@ -1,5 +1,6 @@
 import { h } from "preact";
 import { useRef, useEffect, useCallback } from "preact/hooks";
+import { useBodyClass } from "notes/hooks/use-body-class";
 import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
 
 interface ModalProps {
@@ -18,12 +19,10 @@ interface ModalProps {
 const Modal = ({
   className, title, input, inputValue, cancelValue, confirmValue, validate, onCancel, onConfirm, description,
 }: ModalProps): h.JSX.Element => {
+  useBodyClass("with-modal");
+
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    document.body.classList.add("with-modal");
-    return () => document.body.classList.remove("with-modal");
-  }, []);
 
   useEffect(() => {
     if (inputRef.current) {

--- a/src/notes/hooks/use-body-class.ts
+++ b/src/notes/hooks/use-body-class.ts
@@ -1,0 +1,8 @@
+import { useEffect } from "preact/hooks";
+
+export const useBodyClass = (clazz: string): void => {
+  useEffect(() => {
+    document.body.classList.add(clazz);
+    return () => document.body.classList.remove(clazz);
+  }, []);
+};

--- a/static/notes.css
+++ b/static/notes.css
@@ -591,9 +591,9 @@ body.with-toolbar #toolbar { transform: translateY(0); }
   pointer-events: none;
 }
 
-body.to-create #overlay { background: var(--to-create-overlay-background-color); }
-body.to-rename #overlay { background: var(--to-rename-overlay-background-color); }
-body.to-delete #overlay { background: var(--to-delete-overlay-background-color); }
+body #overlay.to-create { background: var(--to-create-overlay-background-color); }
+body #overlay.to-rename { background: var(--to-rename-overlay-background-color); }
+body #overlay.to-delete { background: var(--to-delete-overlay-background-color); }
 
 /* Modal */
 


### PR DESCRIPTION
Adding a custom hook `useBodyClass` to make it easy to add/remove:
- `with-modal`
- `with-overlay`
- `with-command-palette`

Setting `#overlay` classes (`.to-create`, `.to-rename`, `.to-delete`) to `#overlay` (before set to `body`).

Removing unused (also wrongly named) argument from `DeleteNoteModal`.