### PR TITLE
Add `useKeyboardShortcut` hook

### DIFF
--- a/src/notes/components/SidebarNotes.tsx
+++ b/src/notes/components/SidebarNotes.tsx
@@ -5,7 +5,7 @@ import { SidebarNote } from "notes/adapters";
 import clsx from "clsx";
 import SVG from "types/SVG";
 import LockSvgText from "svg/lock.svg";
-import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
+import { useKeyboardShortcut, KeyboardShortcut } from "notes/hooks/use-keyboard-shortcut";
 import { sendMessage } from "messages";
 
 interface SidebarNotesProps {
@@ -26,6 +26,8 @@ const SidebarNotes = ({
   const [dragOverNote, setDragOverNote] = useState<string | null>(null);
   const [dragOverNoteConfirmation, setDragOverNoteConfirmation] = useState<string | null>(null);
 
+  const [setOnControlHandler] = useKeyboardShortcut(KeyboardShortcut.OnControl);
+
   const [enteredNote, setEnteredNote] = useState<string | null>(null);
   const enteredNoteRef = useRef<string | null>(null);
   enteredNoteRef.current = enteredNote;
@@ -41,7 +43,7 @@ const SidebarNotes = ({
     }
 
     onActivateNote(note);
-  }, [onActivateNote]);
+  }, [active, onActivateNote]);
 
   useEffect(() => {
     setDragOverNote(null);
@@ -51,15 +53,10 @@ const SidebarNotes = ({
   useEffect(() => setNotes(sidebarNotes), [sidebarNotes]);
   useEffect(openEnteredNote, [enteredNote]);
 
-  useEffect(() => {
-    const onControlHandle = () => {
-      document.body.classList.add("with-control");
-      openEnteredNote();
-    };
-
-    keyboardShortcuts.subscribe(KeyboardShortcut.OnControl, onControlHandle);
-    return () => keyboardShortcuts.unsubscribe(onControlHandle);
-  }, []);
+  useEffect(() => setOnControlHandler(() => {
+    document.body.classList.add("with-control");
+    openEnteredNote();
+  }), [openEnteredNote]);
 
   return (
     <Fragment>

--- a/src/notes/components/modals/Modal.tsx
+++ b/src/notes/components/modals/Modal.tsx
@@ -1,7 +1,7 @@
 import { h } from "preact";
 import { useRef, useEffect, useCallback } from "preact/hooks";
 import { useBodyClass } from "notes/hooks/use-body-class";
-import keyboardShortcuts, { KeyboardShortcut } from "notes/keyboard-shortcuts";
+import { useKeyboardShortcut, KeyboardShortcut } from "notes/hooks/use-keyboard-shortcut";
 
 interface ModalProps {
   className?: string
@@ -23,13 +23,15 @@ const Modal = ({
 
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const [setOnCancelHandlerOnEscape] = useKeyboardShortcut(KeyboardShortcut.OnEscape);
+  const [setOnSubmitHandlerOnEnter] = useKeyboardShortcut(KeyboardShortcut.OnEnter);
 
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.value = inputValue ?? "";
       inputRef.current.focus();
     }
-  }, [inputRef]);
+  }, [inputRef, inputValue]);
 
   const onSubmit = useCallback(() => {
     const value = inputRef.current ? inputRef.current.value.trim() : "";
@@ -37,21 +39,10 @@ const Modal = ({
     if (isValid) {
       onConfirm(value);
     }
-  }, []);
+  }, [onConfirm, validate]);
 
-  useEffect(() => {
-    if (cancelValue && onCancel) {
-      keyboardShortcuts.subscribe(KeyboardShortcut.OnEscape, onCancel);
-    }
-    keyboardShortcuts.subscribe(KeyboardShortcut.OnEnter, onSubmit);
-
-    return () => {
-      if (cancelValue && onCancel) {
-        keyboardShortcuts.unsubscribe(onCancel);
-      }
-      keyboardShortcuts.unsubscribe(onSubmit);
-    };
-  }, []);
+  useEffect(() => setOnCancelHandlerOnEscape(onCancel), [onCancel]);
+  useEffect(() => setOnSubmitHandlerOnEnter(onSubmit), [onSubmit]);
 
   return (
     <div id="modal" className={className}>

--- a/src/notes/hooks/use-keyboard-shortcut.ts
+++ b/src/notes/hooks/use-keyboard-shortcut.ts
@@ -1,0 +1,33 @@
+import { useRef, useState, useEffect, useCallback } from "preact/hooks";
+import keyboardShortcuts, { KeyboardShortcut, Callback } from "notes/keyboard-shortcuts";
+export { KeyboardShortcut } from "notes/keyboard-shortcuts";
+
+type Handler = undefined | Callback;
+
+export const useKeyboardShortcut = (keyboardShortcut: KeyboardShortcut) => {
+  const lastHandler = useRef<Handler>(undefined);
+  const [handler, __setHandler] = useState<Handler>();
+
+  useEffect(() => {
+    if (lastHandler.current) {
+      keyboardShortcuts.unsubscribe(lastHandler.current);
+    }
+
+    if (handler) {
+      lastHandler.current = handler;
+      keyboardShortcuts.subscribe(keyboardShortcut, lastHandler.current);
+    }
+
+    return () => {
+      if (lastHandler.current) {
+        keyboardShortcuts.unsubscribe(lastHandler.current);
+      }
+    };
+  }, [handler]);
+
+  const setHandler = useCallback((handler: Handler) => {
+    __setHandler(() => handler);
+  }, []);
+
+  return [setHandler];
+};

--- a/src/notes/keyboard-shortcuts.ts
+++ b/src/notes/keyboard-shortcuts.ts
@@ -39,7 +39,7 @@ export enum KeyboardShortcut {
   OnSync,
 }
 
-type Callback = () => void;
+export type Callback = () => void;
 
 const callbacksByKeyboardShortcut: {
   [shortcut: string]: Callback[] | undefined
@@ -273,7 +273,18 @@ const subscribe = (keyboardShortcut: KeyboardShortcut, callback: Callback): void
 
 const unsubscribe = (callbackToRemove: Callback): void => {
   Object.keys(callbacksByKeyboardShortcut).forEach((shortcut) => {
-    callbacksByKeyboardShortcut[shortcut] = (callbacksByKeyboardShortcut[shortcut] || []).filter((callback) => callback !== callbackToRemove);
+    const callbacks = callbacksByKeyboardShortcut[shortcut];
+    if (!callbacks) {
+      return;
+    }
+
+    const filteredCallbacks = callbacks.filter((callback) => callback !== callbackToRemove);
+    if (!filteredCallbacks.length) {
+      delete callbacksByKeyboardShortcut[shortcut];
+      return;
+    }
+
+    callbacksByKeyboardShortcut[shortcut] = filteredCallbacks;
   });
 };
 

--- a/src/options/Export.tsx
+++ b/src/options/Export.tsx
@@ -1,5 +1,6 @@
 import { h, Fragment } from "preact";
 import clsx from "clsx";
+import { preventEnter } from "shared/components/inputs";
 import { exportNotes } from "notes/export";
 
 let locked = false;
@@ -15,6 +16,7 @@ const Export = ({ canExport }: ExportProps): h.JSX.Element => (
       type="button"
       class={clsx("bold", "button", !canExport && "disabled")}
       value="Export all notes"
+      onKeyPress={preventEnter}
       onClick={() => {
         if (!canExport || locked) {
           return;

--- a/src/shared/components/inputs.tsx
+++ b/src/shared/components/inputs.tsx
@@ -1,0 +1,3 @@
+import { h } from "preact";
+
+export const preventEnter = (e: h.JSX.TargetedKeyboardEvent<HTMLInputElement>) => { e.key === "Enter" && e.preventDefault(); };


### PR DESCRIPTION
`useKeyboardShortcut` hook makes it easy for componenets to use keyboard shortcuts (specifically making sure old handler is removed before new one is added).

Enter key does NOT re-run export (button in Options page).