### PR TITLE
Add shortcut for New note, improve Command palette

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,10 +131,11 @@
   "Shortcuts": "Shortcuts",
   "Shortcuts descriptions": {
     "Open My Notes": "Open My Notes",
-    "Open Options": "Open Options",
+    "New note": "New note",
+    "Options": "Options",
     "Sync notes to and from Google Drive": "Sync notes to and from Google Drive",
-    "Open Command palette": "Open Command palette",
-    "Open Command palette detail": {
+    "Command palette": "Command palette",
+    "Command palette detail": {
       "line1": "By default, Command palette looks for notes <b>by their name.</b>",
       "line2": "Type {{symbol}} first, and continue to start search for <b>commands.</b>",
       "line3": "Type {{symbol}} first, and continue to start search for notes <b>by their content.</b>"

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -480,6 +480,9 @@ const Notes = (): h.JSX.Element => {
     });
   }, [notesProps]);
 
+  const [setOnNewNoteHandler] = useKeyboardShortcut(KeyboardShortcut.OnNewNote);
+  useEffect(() => setOnNewNoteHandler(newNoteModalProps ? undefined : onNewNote), [onNewNote, newNoteModalProps]);
+
   const handleOnActivateNote = useCallback((noteName: string) => {
     if (notesProps.active === noteName || !(noteName in notesProps.notes)) {
       return;
@@ -509,14 +512,14 @@ const Notes = (): h.JSX.Element => {
   ], []);
 
   // Repeat last executed command
-  const [setHandlerOnRepeatLastExecutedCommand] = useKeyboardShortcut(KeyboardShortcut.OnRepeatLastExecutedCommand);
+  const [setOnRepeatLastExecutedCommandHandler] = useKeyboardShortcut(KeyboardShortcut.OnRepeatLastExecutedCommand);
 
   // Command Palette
-  const [setHandlerOnToggleCommandPalette] = useKeyboardShortcut(KeyboardShortcut.OnToggleCommandPalette);
+  const [setOnToggleCommandPaletteHandler] = useKeyboardShortcut(KeyboardShortcut.OnToggleCommandPalette);
   useEffect(() => {
     // Detach when there are no notes
     if (!Object.keys(notesProps.notes).length) {
-      setHandlerOnToggleCommandPalette(undefined);
+      setOnToggleCommandPaletteHandler(undefined);
       setCommandPaletteProps(null);
       return;
     }
@@ -539,14 +542,14 @@ const Notes = (): h.JSX.Element => {
           setCommandPaletteProps(null);
           range.restore(() => {
             foundCommand.command();
-            setHandlerOnRepeatLastExecutedCommand(foundCommand.command);
+            setOnRepeatLastExecutedCommandHandler(foundCommand.command);
           });
         }
       },
     };
 
     // Update event to show Command Palette and props to use
-    setHandlerOnToggleCommandPalette(() => {
+    setOnToggleCommandPaletteHandler(() => {
       setCommandPaletteProps((prev) => {
         if (prev) {
           range.restore();
@@ -564,12 +567,9 @@ const Notes = (): h.JSX.Element => {
 
   // Automatically show modal to create a new note if there are 0 notes
   useEffect(() => {
-    if (!initialized || !tabId || Object.keys(notesProps.notes).length > 0) {
-      setNewNoteModalProps(null);
-      return;
+    if (initialized && typeof tabId === "number" && Object.keys(notesProps.notes).length === 0) {
+      onNewNote(true);
     }
-
-    onNewNote(true);
   }, [initialized, tabId, notesProps, onNewNote]);
 
   // Auto Sync

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -509,9 +509,7 @@ const Notes = (): h.JSX.Element => {
   ], []);
 
   // Repeat last executed command
-  const [lastExecutedCommand, setLastExecutedCommand] = useState<Command | undefined>(undefined);
   const [setHandlerOnRepeatLastExecutedCommand] = useKeyboardShortcut(KeyboardShortcut.OnRepeatLastExecutedCommand);
-  useEffect(() => setHandlerOnRepeatLastExecutedCommand(lastExecutedCommand), [lastExecutedCommand]);
 
   // Command Palette
   const [setHandlerOnToggleCommandPalette] = useKeyboardShortcut(KeyboardShortcut.OnToggleCommandPalette);
@@ -525,10 +523,7 @@ const Notes = (): h.JSX.Element => {
 
     // Start preparing props for Command Palette
     const currentNoteLocked: boolean = notesProps.active in notesProps.notes && notesProps.notes[notesProps.active].locked === true;
-    const commands = currentNoteLocked ? [] : commandPaletteCommands.map((command) => ({
-      name: command.name,
-      translation: command.translation
-    })); // no commands if the current note is locked
+    const commands = currentNoteLocked ? [] : commandPaletteCommands;
 
     // Props for Command Palette
     const props: CommandPaletteProps = {
@@ -544,7 +539,7 @@ const Notes = (): h.JSX.Element => {
           setCommandPaletteProps(null);
           range.restore(() => {
             foundCommand.command();
-            setLastExecutedCommand(foundCommand.command);
+            setHandlerOnRepeatLastExecutedCommand(foundCommand.command);
           });
         }
       },

--- a/src/notes/commands/index.ts
+++ b/src/notes/commands/index.ts
@@ -1,6 +1,7 @@
 import dateUtils from "shared/date/date-utils";
 import table from "./table";
 import highlight from "./highlight";
+import { getFocusOverride } from "notes/location";
 
 export type Command = () => void;
 type CommandFactory<P> = (props: P) => Command;
@@ -96,6 +97,32 @@ const commands: { [key in AvailableCommand]: Command } = {
   RemoveFormat,
 };
 
+const toggleSidebar: Command = () => {
+  if (getFocusOverride()) {
+    return;
+  }
+
+  chrome.storage.local.get(["focus"], local => {
+    if (!local.focus) { // toggle only if not in focus mode
+      const hasSidebar = document.body.classList.toggle("with-sidebar");
+      chrome.storage.local.set({ sidebar: hasSidebar });
+    }
+  });
+};
+
+const toggleToolbar: Command = () => {
+  if (getFocusOverride()) {
+    return;
+  }
+
+  chrome.storage.local.get(["focus"], local => {
+    if (!local.focus) { // toggle only if not in focus mode
+      const hasToolbar = document.body.classList.toggle("with-toolbar");
+      chrome.storage.local.set({ toolbar: hasToolbar });
+    }
+  });
+};
+
 export {
   commands,
 
@@ -106,4 +133,7 @@ export {
 
   table,
   highlight,
+
+  toggleSidebar,
+  toggleToolbar,
 };

--- a/src/notes/components/CommandPalette.tsx
+++ b/src/notes/components/CommandPalette.tsx
@@ -148,6 +148,7 @@ const CommandPalette = ({ notes, commands, onActivateNote, onExecuteCommand }: C
             <div
               className={clsx("command-palette-list-item", index === selectedItemIndex && "active")}
               onClick={() => handleItem(name)}
+              onMouseEnter={() => setSelectedItemIndex(index)}
             >
               {(filter?.type === FilterType.CommandsByName)
                 ? commands.find((command) => command.name === name)?.translation

--- a/src/notes/filters/index.ts
+++ b/src/notes/filters/index.ts
@@ -1,0 +1,3 @@
+import { NotesObject } from "shared/storage/schema";
+
+export const getFirstAvailableNoteName = (notes: NotesObject): string => Object.keys(notes).sort().shift() || "";

--- a/src/notes/keyboard-shortcuts.ts
+++ b/src/notes/keyboard-shortcuts.ts
@@ -3,6 +3,9 @@ import { Os } from "shared/storage/schema";
 const isMac = (os: Os) => os === "mac";
 
 export enum KeyboardShortcut {
+  // New note
+  OnNewNote,
+
   // Options
   OnOpenOptions,
 
@@ -56,6 +59,15 @@ const publish = (keyboardShortcut: KeyboardShortcut, event: KeyboardEvent): void
   }
 
   callbacks.forEach((callback) => callback());
+};
+
+const registerNewNote = (event: KeyboardEvent, os: Os) => {
+  if (
+    (isMac(os) && event.metaKey && event.shiftKey && event.code === "KeyI") ||
+    (!isMac(os) && event.ctrlKey && event.shiftKey && event.code === "KeyI")
+  ) {
+    publish(KeyboardShortcut.OnNewNote, event);
+  }
 };
 
 const registerOpenOptions = (event: KeyboardEvent, os: Os) => {
@@ -218,6 +230,9 @@ const registerSyncNotes = (event: KeyboardEvent, os: Os) => {
 };
 
 const keydown = (os: Os) => document.addEventListener("keydown", (event) => {
+  // New note
+  registerNewNote(event, os);
+
   // Options
   registerOpenOptions(event, os);
 

--- a/src/notes/location.ts
+++ b/src/notes/location.ts
@@ -1,0 +1,2 @@
+export const getFocusOverride = (): boolean => new URL(window.location.href).searchParams.get("focus") === "";
+export const getActiveFromUrl = (): string => new URL(window.location.href).searchParams.get("note") || ""; // Bookmark

--- a/src/options/KeyboardShortcuts.tsx
+++ b/src/options/KeyboardShortcuts.tsx
@@ -23,11 +23,11 @@ const KeyboardShortcuts = ({ os }: KeyboardShortcutsProps): h.JSX.Element => (
             )}
             {shortcut.needsToBeEnabled && <span>{" "}{t("Shortcuts other.if enabled")}</span>}
 
-            {shortcut.description === "Open Command palette" && (
+            {shortcut.description === "Command palette" && (
               <div class="comment">
-                <div>{t("Shortcuts descriptions.Open Command palette detail.line1")}</div>
-                <div>{t("Shortcuts descriptions.Open Command palette detail.line2", { symbol: "<span class=\"keyboard-shortcut\">&gt;</span>" })}</div>
-                <div>{t("Shortcuts descriptions.Open Command palette detail.line3", { symbol: "<span class=\"keyboard-shortcut\">?</span>" })}</div>
+                <div>{t("Shortcuts descriptions.Command palette detail.line1")}</div>
+                <div>{t("Shortcuts descriptions.Command palette detail.line2", { symbol: "<span class=\"keyboard-shortcut\">&gt;</span>" })}</div>
+                <div>{t("Shortcuts descriptions.Command palette detail.line3", { symbol: "<span class=\"keyboard-shortcut\">?</span>" })}</div>
               </div>
             )}
           </td>

--- a/src/options/helpers/keyboard-shortcuts.ts
+++ b/src/options/helpers/keyboard-shortcuts.ts
@@ -15,7 +15,12 @@ const keyboardShortcuts: KeyboardShortcut[] = [
     configurable: true,
   },
   {
-    description: "Open Options",
+    description: "New note",
+    mac: "⌘ + Shift + I",
+    other: "Ctrl + Shift + I",
+  },
+  {
+    description: "Options",
     mac: "⌘ + Shift + O",
     other: "Ctrl + Shift + O",
   },
@@ -25,7 +30,7 @@ const keyboardShortcuts: KeyboardShortcut[] = [
     other: "Ctrl + R",
   },
   {
-    description: "Open Command palette",
+    description: "Command palette",
     mac: "⌘ + P",
     other: "Ctrl + P",
   },

--- a/static/notes.css
+++ b/static/notes.css
@@ -444,6 +444,8 @@ table.locked {
   font-family: inherit;
   font-size: 1em;
   width: 100%;
+  background: var(--command-palette-input-background-color);
+  color: var(--command-palette-input-text-color);
 }
 
 .command-palette-list {
@@ -452,17 +454,24 @@ table.locked {
 }
 
 .command-palette-list-item {
-  cursor: pointer;
   font-weight: bold;
   padding: .5em 1em;
   background: var(--command-palette-item-background-color);
   color: var(--command-palette-item-text-color);
 }
 
-.command-palette-list-item:not(.plain):hover,
-.command-palette-list-item:not(.plain).active {
-  background: var(--command-palette-active-item-background-color);
-  color: var(--command-palette-active-item-text-color);
+.command-palette-list-item:not(.plain) {
+  cursor: pointer;
+}
+
+.command-palette-list-item:not(.plain):hover {
+  background: var(--command-palette-item-hover-background-color);
+  color: var(--command-palette-item-hover-text-color);
+}
+
+.command-palette-list-item.active {
+  background: var(--command-palette-active-item-background-color) !important;
+  color: var(--command-palette-active-item-text-color) !important;
 }
 
 body.with-command-palette #sidebar,

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -96,9 +96,13 @@
 
   /* Command palette */
 
+  --command-palette-input-background-color: #2c2c2c;
+  --command-palette-input-text-color: white;
   --command-palette-border-color: #454545;
   --command-palette-item-background-color: #121212;
   --command-palette-item-text-color: #626262;
+  --command-palette-item-hover-background-color: #181818;
+  --command-palette-item-hover-text-color: white;
   --command-palette-active-item-background-color: #222;
   --command-palette-active-item-text-color: white;
 

--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -96,9 +96,13 @@
 
   /* Command palette */
 
+  --command-palette-input-background-color: white;
+  --command-palette-input-text-color: black;
   --command-palette-border-color: silver;
   --command-palette-item-background-color: #f5f5f5;
   --command-palette-item-text-color: black;
+  --command-palette-item-hover-background-color: #d6d6d6;
+  --command-palette-item-hover-text-color: black;
   --command-palette-active-item-background-color: #bdbdbd;
   --command-palette-active-item-text-color: black;
 


### PR DESCRIPTION
- Adding a new keyboard shortcut (`Ctrl/Cmd + Shift + I`) to create a **New note**.
- Adding an alternative way to toggle **Sidebar** or **Toolbar** via the the Command palette.
- Fixed **"Repeat last command"**.
- Command palette tweaks:
  - Lighter color on **mouse hover** (to easily distinguish mouse or cursor activated list item)
  - Automatically activated list item on **mouse hover** (so can easily continue using arrow keys from that point if needed)
  - Using a better color for Command palette input in Dark mode

Closes https://github.com/penge/my-notes/issues/345
Closes https://github.com/penge/my-notes/issues/368