### PR TITLE
Pin notes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  testMatch: [
+    "**/__tests__/**/*.test.ts?(x)"
+  ],
   moduleDirectories: ["node_modules", "src"]
 };

--- a/src/background/init/migrations/__tests__/core-existing-values.test.ts
+++ b/src/background/init/migrations/__tests__/core-existing-values.test.ts
@@ -1,9 +1,9 @@
-import { NotesOrder, Storage } from "shared/storage/schema";
+import { Storage, NotesOrder } from "shared/storage/schema";
 import migrate from "../core";
-import { expectItems } from "./core-default-values.test";
+import { expectItems } from "./helpers";
 
-it("sets custom values", () => {
-  const local = {
+it("uses existing values and adds any omitted properties set to their defaults to make a complete Storage", () => {
+  const existing: Partial<Storage> = {
     font: {
       id: "roboto-mono",
       name: "Roboto Mono",
@@ -52,12 +52,15 @@ it("sets custom values", () => {
     tabSize: 2,
   };
 
-  const items: Storage = migrate({}, local);
-  expectItems(Object.assign({}, items));
+  const items: Storage = migrate({}, existing);
+  expectItems(items);
 
-  // Compare objects
   expect(items).toEqual(Object.assign({
-    // Automatically added properties to make a complete object (interface Storage)
+    /**
+     * Omitted properties below are added and set to their defaults
+     * to make a complete Storage.
+     * See {@link Storage}
+     */
     order: [],
     notesOrder: NotesOrder.Alphabetical,
     sidebar: true,
@@ -66,5 +69,5 @@ it("sets custom values", () => {
     setBy: "",
     lastEdit: "",
     openNoteOnMouseHover: false,
-  }, local));
+  } as Partial<Storage>, existing));
 });

--- a/src/background/init/migrations/__tests__/helpers.ts
+++ b/src/background/init/migrations/__tests__/helpers.ts
@@ -1,0 +1,4 @@
+import { Storage } from "shared/storage/schema";
+import { localKeys } from "../core";
+
+export const expectItems = (items: Storage): void => expect(Object.keys(items)).toEqual(localKeys);

--- a/src/background/init/migrations/core.ts
+++ b/src/background/init/migrations/core.ts
@@ -1,5 +1,5 @@
 
-import { NotesObject, NotesOrder, Storage } from "shared/storage/schema";
+import { NotesObject, NotesOrder, Storage, StorageKey } from "shared/storage/schema";
 import { defaultValuesFactory } from "shared/storage/default-values";
 import {
   validBoolean,
@@ -12,7 +12,7 @@ import {
   validNotesOrder,
 } from "shared/storage/validations";
 
-export const expectedKeys = [
+export const localKeys: StorageKey[] = [
   // Appearance
   "font",
   "size",
@@ -88,8 +88,8 @@ export default (sync: { [key: string]: unknown }, local: { [key: string]: unknow
     notes: notes as NotesObject, // already migrated to [3.x]
     order: validStringArray(local.order) ? local.order : [],
     active: tryNote(local.active as string) || tryNote(defaultValues.active as string) || firstAvailableNote,
-    setBy: local.setBy as string || "",
-    lastEdit: local.lastEdit as string || "",
+    setBy: typeof local.setBy === "string" ? local.setBy : defaultValues.setBy,
+    lastEdit: typeof local.lastEdit === "string" ? local.lastEdit : defaultValues.lastEdit,
 
     // Options
     notesOrder: validNotesOrder(local.notesOrder) ? local.notesOrder : NotesOrder.Alphabetical,

--- a/src/background/init/migrations/index.ts
+++ b/src/background/init/migrations/index.ts
@@ -1,9 +1,9 @@
 import { Storage } from "shared/storage/schema";
-import migrate, { expectedKeys } from "./core";
+import migrate, { localKeys } from "./core";
 
 export const runMigrations = (): void => {
   chrome.storage.sync.get(["newtab", "value", "notes"], sync => {
-    chrome.storage.local.get(expectedKeys, local => {
+    chrome.storage.local.get(localKeys, local => {
       const items: Storage = migrate(sync, local); // migrate notes and options
       chrome.storage.local.set(items); // store the migrated data
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,8 @@
   "Yes": "Yes",
   "Lock": "Lock",
   "Unlock": "Unlock",
+  "Pin": "Pin",
+  "Unpin": "Unpin",
   "Duplicate": "Duplicate",
   "Export": "Export",
   "Google Drive Sync is disabled (see Options)": "Google Drive Sync is disabled (see Options)",

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -34,7 +34,7 @@ import renameNote from "notes/state/rename-note";
 import deleteNote from "notes/state/delete-note";
 import duplicateNote from "notes/state/duplicate-note";
 
-import { saveNote, setLocked } from "notes/content/save";
+import { saveNote, setLocked, setPinnedTime } from "notes/content/save";
 import { sendMessage } from "messages";
 
 import { getActiveFromUrl, getFocusOverride } from "notes/location";
@@ -630,6 +630,11 @@ const Notes = (): h.JSX.Element => {
             onToggleLocked: (noteName) => {
               setContextMenuProps(null);
               tabId && notesRef.current && setLocked(noteName, !(notesProps.notes[noteName].locked ?? false), tabId, notesRef.current);
+            },
+            pinned: !!notesProps.notes[noteName].pinnedTime,
+            onTogglePinnedTime: (noteName) => {
+              setContextMenuProps(null);
+              tabId && notesRef.current && setPinnedTime(noteName, (notesProps.notes[noteName].pinnedTime ?? undefined) ? undefined : new Date().toISOString(), tabId, notesRef.current);
             },
             onDuplicate: (noteName) => {
               setContextMenuProps(null);

--- a/src/notes/components/ContextMenu.tsx
+++ b/src/notes/components/ContextMenu.tsx
@@ -11,12 +11,14 @@ export interface ContextMenuProps {
   onDelete: (noteName: string) => void
   locked: boolean
   onToggleLocked: (noteName: string) => void
+  pinned: boolean
+  onTogglePinnedTime: (noteName: string) => void
   onDuplicate: (noteName: string) => void
   onExport: (noteName: string) => void
 }
 
 const ContextMenu = ({
-  noteName, x, y, onRename, onDelete, locked, onToggleLocked, onDuplicate, onExport,
+  noteName, x, y, onRename, onDelete, locked, onToggleLocked, pinned, onTogglePinnedTime, onDuplicate, onExport,
 }: ContextMenuProps): h.JSX.Element => {
   const [offsetHeight, setOffsetHeight] = useState<number>(0);
   const ref = useRef<HTMLDivElement>(null);
@@ -44,6 +46,7 @@ const ContextMenu = ({
       <div class={clsx("action", locked && "disabled")} onClick={() => !locked && onRename(noteName)}>{t("Rename")}</div>
       <div class={clsx("action", locked && "disabled")} onClick={() => !locked && onDelete(noteName)}>{t("Delete")}</div>
       <div class="action" onClick={() => onToggleLocked(noteName)}>{locked ? t("Unlock") : t("Lock")}</div>
+      <div class="action" onClick={() => onTogglePinnedTime(noteName)}>{pinned ? t("Unpin") : t("Pin")}</div>
       <div class="action" onClick={() => onDuplicate(noteName)}>{t("Duplicate")}</div>
       <div class="action" onClick={() => onExport(noteName)}>{t("Export")}</div>
     </div>

--- a/src/notes/components/Sidebar.tsx
+++ b/src/notes/components/Sidebar.tsx
@@ -1,8 +1,8 @@
 import { h } from "preact";
-import { useRef } from "preact/hooks";
+import { useRef, useState, useMemo } from "preact/hooks";
 import { Os, Sync } from "shared/storage/schema";
 import { SidebarNote } from "notes/adapters";
-import SidebarNotes from "./SidebarNotes";
+import SidebarNotes, { SidebarNotesProps } from "./SidebarNotes";
 import SidebarButtons from "./SidebarButtons";
 import Drag from "./Drag";
 
@@ -24,6 +24,18 @@ const Sidebar = ({
   os, notes, canChangeOrder, onChangeOrder, active, width, onActivateNote, onNoteContextMenu, onNewNote, sync, openNoteOnMouseHover,
 }: SidebarProps): h.JSX.Element => {
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const [onDraggingNoteOriginator, setOnDraggingNoteOriginator] = useState<string | undefined>(undefined);
+  const commonSidebarNotesProps: Omit<SidebarNotesProps, "id" | "notes" | "canDragEnter" | "onChangeOrder"> = {
+    active,
+    onActivateNote,
+    onNoteContextMenu,
+    canChangeOrder,
+    openNoteOnMouseHover,
+    setOnDraggingNoteOriginator,
+  };
+
+  const pinnedNotes = useMemo(() => notes.filter((note) => note.pinnedTime), [notes]);
+  const unpinnedNotes = useMemo(() => notes.filter((note) => !note.pinnedTime), [notes]);
 
   return (
     <div
@@ -34,15 +46,37 @@ const Sidebar = ({
         minWidth: width,
       }}
     >
-      <SidebarNotes
-        notes={notes}
-        active={active}
-        onActivateNote={onActivateNote}
-        onNoteContextMenu={onNoteContextMenu}
-        canChangeOrder={canChangeOrder}
-        onChangeOrder={onChangeOrder}
-        openNoteOnMouseHover={openNoteOnMouseHover}
-      />
+      <div id="sidebar-notes-container">
+        {pinnedNotes.length > 0 && (
+          <SidebarNotes
+            id="sidebar-notes-pinned"
+            notes={pinnedNotes}
+            {...commonSidebarNotesProps}
+            canDragEnter={onDraggingNoteOriginator === "sidebar-notes-pinned"}
+            onChangeOrder={(newOrder) => onChangeOrder([
+              ...newOrder,
+              ...unpinnedNotes.map((note) => note.name),
+            ])}
+          />
+        )}
+
+        {pinnedNotes.length > 0 && unpinnedNotes.length > 0 && (
+          <div id="sidebar-notes-separator" />
+        )}
+
+        {unpinnedNotes.length > 0 && (
+          <SidebarNotes
+            id="sidebar-notes-unpinned"
+            notes={unpinnedNotes}
+            {...commonSidebarNotesProps}
+            canDragEnter={onDraggingNoteOriginator === "sidebar-notes-unpinned"}
+            onChangeOrder={(newOrder) => onChangeOrder([
+              ...pinnedNotes.map((note) => note.name),
+              ...newOrder,
+            ])}
+          />
+        )}
+      </div>
 
       <SidebarButtons
         os={os}

--- a/src/notes/components/SidebarNotes.tsx
+++ b/src/notes/components/SidebarNotes.tsx
@@ -8,18 +8,21 @@ import LockSvgText from "svg/lock.svg";
 import { useKeyboardShortcut, KeyboardShortcut } from "notes/hooks/use-keyboard-shortcut";
 import { sendMessage } from "messages";
 
-interface SidebarNotesProps {
+export interface SidebarNotesProps {
+  id: string
   notes: SidebarNote[]
   active: string
   onActivateNote: (noteName: string) => void
   onNoteContextMenu: (noteName: string, x: number, y: number) => void
+  openNoteOnMouseHover: boolean
+  canDragEnter: boolean
+  setOnDraggingNoteOriginator: (id: string | undefined) => void
   canChangeOrder: boolean
   onChangeOrder: (newOrder: string[]) => void
-  openNoteOnMouseHover: boolean
 }
 
 const SidebarNotes = ({
-  notes: sidebarNotes, active, onActivateNote, onNoteContextMenu, canChangeOrder, onChangeOrder, openNoteOnMouseHover,
+  id, notes: sidebarNotes, active, onActivateNote, onNoteContextMenu, openNoteOnMouseHover, canDragEnter, setOnDraggingNoteOriginator, canChangeOrder, onChangeOrder,
 }: SidebarNotesProps): h.JSX.Element => {
   const [notes, setNotes] = useState<SidebarNote[]>(sidebarNotes);
 
@@ -59,11 +62,13 @@ const SidebarNotes = ({
     openEnteredNote();
   }), [openEnteredNote]);
 
+  useEffect(() => setOnDraggingNoteOriginator(draggedNote ? id : undefined), [id, draggedNote]);
+
   return (
     <Fragment>
       <div
-        id="sidebar-notes"
-        className={clsx("notes", draggedNote && "dragging")}
+        id={id}
+        className={clsx("sidebar-notes", draggedNote && "dragging")}
       >
         {notes.map((note, index) =>
           <div
@@ -116,7 +121,7 @@ const SidebarNotes = ({
             }}
             onDragOver={(event) => {
               event.preventDefault();
-              if (note.locked || draggedNote) {
+              if (note.locked || draggedNote || !canDragEnter) {
                 return;
               }
 

--- a/src/notes/content/save.ts
+++ b/src/notes/content/save.ts
@@ -29,3 +29,7 @@ export const saveNote = (noteName: string, content: string, tabId: number, notes
 export const setLocked = (noteName: string, locked: boolean, tabId: number, notes: NotesObject): void => {
   saveNoteCore(noteName, tabId, notes, { locked });
 };
+
+export const setPinnedTime = (noteName: string, pinnedTime: string | undefined, tabId: number, notes: NotesObject): void => {
+  saveNoteCore(noteName, tabId, notes, { pinnedTime });
+};

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,6 +1,6 @@
 import { h, Fragment } from "preact";
 import { useCallback } from "preact/hooks";
-import { Os, Sync } from "shared/storage/schema";
+import { Os, Sync, StorageKey } from "shared/storage/schema";
 import formatDate from "shared/date/format-date";
 import { requestPermission, removePermission } from "shared/permissions";
 import keyboardShortcuts from "./helpers/keyboard-shortcuts";
@@ -23,7 +23,7 @@ const Options = ({ os, sync, autoSync, tab, tabSize, openNoteOnMouseHover }: Opt
   const openNoteOnMouseHoverKeyboardShortcut = keyboardShortcuts.find((item) => item.description === "Open note on mouse hover");
   const openNoteOnMouseHoverKey = openNoteOnMouseHoverKeyboardShortcut && openNoteOnMouseHoverKeyboardShortcut[os];
 
-  const toggleOption = useCallback((key: string) => (event: h.JSX.TargetedMouseEvent<HTMLInputElement>) => {
+  const toggleOption = useCallback((key: StorageKey) => (event: h.JSX.TargetedMouseEvent<HTMLInputElement>) => {
     const checked = (event.target as HTMLInputElement).checked;
     chrome.storage.local.set({ [key]: checked });
   }, []);

--- a/src/shared/storage/default-values.ts
+++ b/src/shared/storage/default-values.ts
@@ -28,10 +28,10 @@ const defaultValuesFactory = (generateNotes?: boolean): Storage => {
       fontFamily: "Helvetica, sans-serif",
     },
     size: 200,
-    sidebar: true,
-    toolbar: true,
     theme: "light",
     customTheme: "", // css string
+    sidebar: true,
+    toolbar: true,
 
     // Notes
     notes,

--- a/src/shared/storage/schema.ts
+++ b/src/shared/storage/schema.ts
@@ -96,6 +96,8 @@ export interface Storage {
   autoSync: boolean
 }
 
+export type StorageKey = keyof Storage
+
 export interface ContextMenuSelection {
   text: string
   sender: string

--- a/src/shared/storage/schema.ts
+++ b/src/shared/storage/schema.ts
@@ -8,6 +8,7 @@ export interface Note {
     file: GoogleDriveFile
   }
   locked?: boolean
+  pinnedTime?: string
 }
 
 export interface RegularFont {

--- a/static/notes.css
+++ b/static/notes.css
@@ -142,15 +142,22 @@ body.with-sidebar #sidebar { transform: translateX(0); }
 body.with-sidebar { left: var(--default-sidebar-width); }
 body:not(.with-sidebar) { left: 0 !important; }
 
-#sidebar-notes {
-  padding: .5em;
-  overflow-y: auto;
+#sidebar-notes-container {
   flex-grow: 1;
   background: var(--sidebar-notes-background-color);
   color: var(--sidebar-notes-text-color);
 }
 
-#sidebar-notes .note {
+#sidebar-notes-separator {
+  height: 1em;
+}
+
+.sidebar-notes {
+  padding: .5em;
+  overflow-y: auto;
+}
+
+.sidebar-notes .note {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -161,18 +168,18 @@ body:not(.with-sidebar) { left: 0 !important; }
   border-radius: 3px;
 }
 
-#sidebar-notes .note svg {
+.sidebar-notes .note svg {
   height: 1em;
   flex-shrink: 0;
 }
 
-#sidebar-notes .note:hover,
-#sidebar-notes .note.active {
+.sidebar-notes .note:hover,
+.sidebar-notes .note.active {
   background: var(--sidebar-active-note-background-color);
   color: var(--sidebar-active-note-text-color);
 }
 
-#sidebar-notes .note.drag-over {
+.sidebar-notes .note.drag-over {
   background: var(--selection-background-color);
   color: var(--selection-text-color);
 }
@@ -188,18 +195,18 @@ body:not(.with-sidebar) { left: 0 !important; }
   }
 }
 
-#sidebar-notes .note.drag-confirmation {
+.sidebar-notes .note.drag-confirmation {
   animation: confirmation .3s cubic-bezier(1, 0, 0.5, 1) 2 alternate;
 }
 
-#sidebar-notes.dragging .note,
-#sidebar-notes.dragging .note.active,
-#sidebar-notes.dragging .note.drag-over {
+.sidebar-notes.dragging .note,
+.sidebar-notes.dragging .note.active,
+.sidebar-notes.dragging .note.drag-over {
   background: none !important;
   color: var(--sidebar-notes-text-color) !important;
 }
 
-#sidebar-notes.dragging .note.dragging {
+.sidebar-notes.dragging .note.dragging {
   background: transparent !important;
   color: transparent !important;
   box-shadow: inset 0 0 0px 1px silver;
@@ -242,7 +249,7 @@ body.resizing-sidebar #drag {
   border-color: var(--drag-resizing-border-color);
 }
 
-body.resizing-sidebar #sidebar-notes,
+body.resizing-sidebar #sidebar-notes-container,
 body.resizing-sidebar #sidebar-buttons,
 body.resizing-sidebar #content,
 body.resizing-sidebar #toolbar {


### PR DESCRIPTION
Adding a feature that allows to **Pin** (and **Unpin**) notes via a new context menu from the Sidebar.

Note: _Pinned_ notes follow the same **Order** option (see Options) as _Unpinned_ notes. _Pinned_ and _Unpinned_ notes are ordered as two separate groups.

Closes https://github.com/penge/my-notes/issues/370