### PR TITLE
Fix renaming and deleting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "My Notes",
   "description": "Simple and fast note-taking.",
-  "version": "3.22",
+  "version": "3.22.1",
   "homepage_url": "https://github.com/penge/my-notes",
   "icons": {
     "128": "images/icon128.png"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-notes",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-notes",
-      "version": "3.22.0",
+      "version": "3.22.1",
       "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-notes",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "Simple and fast note-taking.",
   "author": "Pavel Bucka",
   "license": "MIT",

--- a/src/notes.tsx
+++ b/src/notes.tsx
@@ -687,7 +687,7 @@ const Notes = (): h.JSX.Element => {
           <__Content
             note={{
               ...contentNote,
-              locked: notesProps.notes[contentNote.active].locked || false,
+              locked: contentNote.active in notesProps.notes ? (notesProps.notes[contentNote.active].locked || false) : false,
             }}
             onEdit={(active, content) => {
               tabId && notesRef.current && saveNote(active, content, tabId, notesRef.current);


### PR DESCRIPTION
Renaming or deleting the note was not working as there was problem in trying to access a note under the old name if renamed, or under unexisting name if deleted.

Releasing as version 3.22.1.