### PR TITLE
Fix time and dateTime parsing

### DIFF
--- a/src/shared/date/__tests__/format-date.test.ts
+++ b/src/shared/date/__tests__/format-date.test.ts
@@ -1,4 +1,4 @@
-import formatDate from "../format-date";
+import formatDate, { FormatDateOption } from "../format-date";
 
 it("returns empty string for invalid date", () => {
   expect(formatDate("")).toBe("");
@@ -8,4 +8,12 @@ it("returns empty string for invalid date", () => {
 it("returns US format date string", () => {
   expect(formatDate("2021-01-08T09:41:01Z")).toBe("2021 January 8, 9:41:01 AM");
   expect(formatDate("2021-01-25T14:30:58Z")).toBe("2021 January 25, 2:30:58 PM");
+});
+
+it("can return date only", () => {
+  expect(formatDate("2021-01-25T14:30:58Z", FormatDateOption.ONLY_DATE)).toBe("2021 January 25");
+});
+
+it("can return time only", () => {
+  expect(formatDate("2021-01-25T14:30:58Z", FormatDateOption.ONLY_TIME)).toBe("2:30:58 PM");
 });

--- a/src/shared/date/__tests__/parse-date.test.ts
+++ b/src/shared/date/__tests__/parse-date.test.ts
@@ -8,9 +8,9 @@ it("returns undefined for invalid date", () => {
 it("returns parsed date", () => {
   const date = "2021-01-08T09:41:01Z";
   const expected: ParsedDate = {
-    year: "2021",
+    year: 2021,
     month: "January",
-    day: "8",
+    day: 8,
     date: "2021 January 8",
     time: "9:41:01 AM",
     dateTime: "2021 January 8, 9:41:01 AM"

--- a/src/shared/date/parse-date.ts
+++ b/src/shared/date/parse-date.ts
@@ -1,7 +1,19 @@
+const locale = "en-US";
+
+const monthOptions: Intl.DateTimeFormatOptions = {
+  month: "long",
+};
+
+const timeOptions: Intl.DateTimeFormatOptions = {
+  hour: "numeric",
+  minute: "2-digit",
+  second: "2-digit"
+};
+
 export interface ParsedDate {
-  year: string
+  year: number
   month: string
-  day: string
+  day: number
 
   date: string
   time: string
@@ -18,20 +30,21 @@ export default (ISOString: string): ParsedDate | undefined => {
     return;
   }
 
-  const dateString = dateObject.toLocaleString("en-US", {
-    year: "numeric",
-    month: "long", // "May", "January"
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit"
-  });
+  const year = dateObject.getFullYear();
+  const month = dateObject.toLocaleString(locale, monthOptions);
+  const day = dateObject.getDate();
 
-  const parts = dateString.split(",").map((part) => part.trim());
-  const date = `${parts[1]} ${parts[0]}`; // e.g. "2021 April 4"
-  const time = parts[2]; // e.g. "4:03:44 PM"
-  const dateTime = `${date}, ${time}`; // e.g. "2021 April 4, 4:03:44 PM"
-  const [year, month, day] = date.split(" "); // e.g. ["2021", "April", "4"]
+  const date = `${year} ${month} ${day}`;
+  const time = dateObject.toLocaleString(locale, timeOptions);
+  const dateTime = `${date}, ${time}`;
 
-  return { year, month, day, date, time, dateTime };
+  return {
+    year,
+    month,
+    day,
+
+    date,
+    time,
+    dateTime,
+  };
 };


### PR DESCRIPTION
Because relying on `toLocaleString` to parse **_date_**, **_time_**, or **_date+time_** to locale language, turned out there was an update and `en-US` locale uses now **" at "** as **_date+time_** separator compared to previous **", "**. This caused problem to parse the **_time_** portion.
As any locale can have different **_date+time_** separator or the separator can change as it happened now, the current solution wasn't reliable. Instead, I am updating this parsing so it does _NOT_ rely on any **_date+time_** separator, which solved the problem.