### PR TITLE
Indent and outdent lists using Tab

### DIFF
--- a/src/notes/content/list.ts
+++ b/src/notes/content/list.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/prefer-default-export
+export const insideListItem = ({ canBeFirstDescendant }: { canBeFirstDescendant: boolean }) => {
+  const selection = window.getSelection();
+  if (!selection || !selection.rangeCount) {
+    return false;
+  }
+
+  const LIST_TAGS = ["UL", "OL"];
+  const ancestor = selection.getRangeAt(0).commonAncestorContainer;
+  const closestList = LIST_TAGS.includes((ancestor as HTMLOListElement | HTMLUListElement).tagName)
+    ? ancestor
+    : ancestor.parentElement?.closest(LIST_TAGS.join(","));
+
+  return canBeFirstDescendant
+    ? closestList != null
+    : LIST_TAGS.includes(closestList?.parentElement?.tagName || "");
+};

--- a/src/notes/keyboard-shortcuts.ts
+++ b/src/notes/keyboard-shortcuts.ts
@@ -20,6 +20,7 @@ export enum KeyboardShortcut {
   OnEscape,
   OnEnter,
   OnTab,
+  OnShiftTab,
 
   // Commands
   OnRepeatLastExecutedCommand,
@@ -137,8 +138,14 @@ const registerEnter = (event: KeyboardEvent) => {
 };
 
 const registerTab = (event: KeyboardEvent) => {
-  if (event.key === "Tab") {
+  if (event.key === "Tab" && !event.shiftKey) {
     publish(KeyboardShortcut.OnTab, event);
+  }
+};
+
+const registerShiftTab = (event: KeyboardEvent) => {
+  if (event.key === "Tab" && event.shiftKey) {
+    publish(KeyboardShortcut.OnShiftTab, event);
   }
 };
 
@@ -247,6 +254,7 @@ const keydown = (os: Os) => document.addEventListener("keydown", (event) => {
   registerEscape(event);
   registerEnter(event);
   registerTab(event);
+  registerShiftTab(event);
 
   // Commands
   registerRepeatLastExecutedCommand(event, os);


### PR DESCRIPTION
It is now easier to **_indent_** and **_outdent_** lists as it can be done with `Tab` and `Shift + Tab` keys. In order for this to work, option _Indent text on Tab_ needs to be enabled (see Options).

Closes https://github.com/penge/my-notes/issues/398